### PR TITLE
Clarification of congestion control section

### DIFF
--- a/draft-lmbdhk-quic-multipath.md
+++ b/draft-lmbdhk-quic-multipath.md
@@ -587,7 +587,7 @@ Path Identifier: An identifier of the path, which is formatted as shown in {{fig
     sending data over the specified path. This method MUST NOT be used if this connection
     identifier is zero-length.
   - Type 2: Refer to the path over which the control frame is sent or received.
-- Path Identifier Content: A variable-length integer specifying the path identifier. If Identifier Type is 2, 
+- Path Identifier Content: A variable-length integer specifying the path identifier. If Identifier Type is 2,
 the Path Identifier Content MUST be empty.
 
 ~~~


### PR DESCRIPTION
Some more text in the congestion control section explaining why coupled congestion control is suggested. We could later add SHOULD or MUST to request the utilization of coupled congestion control schemes for multipath QUIC.