### PR TITLE
Moving second part of PR#99 to section 3

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -237,7 +237,13 @@ header.
 # Path Setup and Removal {#setup}
 
 After completing the handshake, endpoints have agreed to enable
-multipath feature and can start using multiple paths. This document
+multipath feature and can start using multiple paths. This document 
+does not specify how an endpoint that is reachable via several addresses
+announces these addresses to the other endpoint. In particular, if the
+server uses the preferred_address transport parameter, clients 
+SHOULD NOT assume that the initial server address and the addrresses 
+contained in this parameter can be simultaneously used for multipath. 
+Furthermore, this document
 does not discuss when a client decides to initiate a new path. We
 delegate such discussion in separate documents.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -241,7 +241,7 @@ multipath feature and can start using multiple paths. This document
 does not specify how an endpoint that is reachable via several addresses
 announces these addresses to the other endpoint. In particular, if the
 server uses the preferred_address transport parameter, clients 
-SHOULD NOT assume that the initial server address and the addrresses 
+SHOULD NOT assume that the initial server address and the addresses 
 contained in this parameter can be simultaneously used for multipath. 
 Furthermore, this document
 does not discuss when a client decides to initiate a new path. We


### PR DESCRIPTION
Attempt at moving 

Further, it is out of scope for
this document if the old address can also be used for multipath
after a client has migrated to the address provided in the preferred_address
transport parameter. However, it SHOULD NOT be assumed that it is
possible to use both addresses simultaneously without further confirmation
from the other host.

In the beginning of section where I think it would be more appropriate.
