### PR TITLE
Add more explanation on ACK delay, RTT computation for single PNS

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -724,7 +724,7 @@ can be used:
   time of that packet. When an ACK is sent on that path, the ACK Delay field is
   re-calculated using that path's largest packet receive time.
 
-* Each path also keeps track of a list of sent packets that are acknowledged by
+* The sender also keeps track of a list of sent packets for each path that are acknowledged by
   ACKs from the same path. A path's RTT sample is generated on receving ACK
   that meets the following two conditions: (1) For that path, the largest
   same-path acknowledged packet number is updated. (2) One of newly same-path

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -715,7 +715,7 @@ If one chooses not to use time-stamps but wants to get reasonable estimation of
 RTTs on multiple paths with one packet number space, the following practices
 can be used:
 
-* Each path counts the number of ACK-eliciting packets received on that path,
+* The receiver side counts the number of ACK-eliciting packets received for each paths,
   and keeps a per-path ACK timer. An ACK from that path is triggered when the
   number of ACK-eliciting packets received on that path surpasses the path's
   ACK-eliciting threshold or the path's ACK-timer expires.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -714,17 +714,17 @@ packet was sent. However, when applying the above algorithm with SPNS, one may
 encounter the following issues: (1) RTT of some paths are not updated timely if
 ACKs are mostly returned from other paths, and (2) ACK frames depend on the
 largest received packet of the connection, not the path, and the resulted RTT
-sample may be the sum of the uplink delay of one path and the downlink delay of
-another path. One solution for accurate RTT measurements is to employ
-time-stamps as described in {{QUIC-Timestamp}}. If one chooses not to use
-time-stamps but wants to get reasonable estimation of RTTs on multiple paths
-with single packet number space, the following practices can be used:
+sample may be the sum of the one-way delays of two different paths. One
+solution for accurate RTT measurements is to employ time-stamps as described in
+{{QUIC-Timestamp}}. If one chooses not to use time-stamps but wants to get
+reasonable estimation of RTTs on multiple paths with single packet number
+space, the following practices can be used:
 
 For packet receiver (ACK sender):
 
 * Maintain an ACK threshold and an ACK timer for each path. A path should send
-an ACK when it receives ack-eliciting threshold number of ack-eliciting
-packets (e.g., two). And an ack-eliciting packet must be acknowledged within
+an ACK when it receives ack-eliciting-threshold number of ack-eliciting
+packets (e.g., two) on this path, and an ack-eliciting packet must be acknowledged within
 MAX_ACK_DELAY.
 
 * Write ACK frame based on the largest received packet of the path. Start the ACK

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -716,9 +716,9 @@ RTTs on multiple paths with one packet number space, the following practices
 can be used:
 
 * The receiver side counts the number of ACK-eliciting packets received for each paths,
-  and keeps a per-path ACK timer. An ACK from that path is triggered when the
-  number of ACK-eliciting packets received on that path surpasses the path's
-  ACK-eliciting threshold or the path's ACK-timer expires.
+  and keeps a per-path ACK timer. An ACK from that path is triggered when either
+  a) the number of ACK-eliciting packets received on that path surpasses the path's
+  ACK-eliciting threshold or b) the path's ACK-timer expires.
 
 * Each path records the largest packet received on that path and the receive
   time of that packet. When an ACK is sent on that path, the ACK Delay field is

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -725,7 +725,7 @@ can be used:
   re-calculated using that path's largest packet receive time.
 
 * The sender also keeps track of a list of sent packets for each path that are acknowledged by
-  ACKs from the same path. A path's RTT sample is generated on receving ACK
+  ACKs received from the same path. A path's RTT sample is generated on receving ACK
   that meets the following two conditions: (1) For that path, the largest
   same-path acknowledged packet number is updated. (2) One of newly same-path
   acknowledged packets is ACK-eliciting.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -702,7 +702,7 @@ maintaining an order list of packets sent on each path. That ordered
 list can then be used to compute acknowledgement gaps per path in
 Packet Threshold tests.
 
-### ACK Delay and Zero-Length CID Considerations
+### ACK Delay, RTT, and Zero-Length CID Considerations {#ack-delay-and-zero-length-cid-considerations}
 
 The ACK Delay field of the ACK frame is relative to the largest
 acknowledged packet number (see {{Section 13.2.5 of QUIC-TRANSPORT}}).
@@ -710,6 +710,26 @@ When using paths with different transmission delays, the reported host
 delay will most of the time relate to the path with the shortest latency.
 To collect ACK delays on all the paths, hosts should rely on time stamps
 as described in {{QUIC-Timestamp}}.
+
+If one chooses not to use time-stamps but wants to get reasonable estimation of
+RTTs on multiple paths with one packet number space, the following practices
+can be used:
+
+* Each path counts the number of ACK-eliciting packets received on that path,
+  and keeps a per-path ACK timer. An ACK from that path is triggered when the
+  number of ACK-eliciting packets received on that path surpasses the path's
+  ACK-eliciting threshold or the path's ACK-timer expires.
+
+* Each path records the largest packet received on that path and the receive
+  time of that packet. When an ACK is sent on that path, the ACK Delay field is
+  re-calculated using that path's largest packet receive time.
+
+* Each path also keeps track of a list of sent packets that are acknowledged by
+  ACKs from the same path. A path's RTT sample is generated on receving ACK
+  that meets the following two conditions: (1) For that path, the largest
+  same-path acknowledged packet number is updated. (2) One of newly same-path
+  acknowledged packets is ACK-eliciting.
+
 
 ### ECN and Zero-Length CID Considerations {#ecn-handling}
 


### PR DESCRIPTION
For issue #125 , add some considerations for RTT computation in our single pns implementation. Not sure if it is easy enough to understand. Please feel free to change.