### PR TITLE
Do not imply

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -318,7 +318,7 @@ that path.
 
 An endpoint that wants to close a path SHOULD use explicit request to
 terminate the path by sending the PATH_ABANDON frame (see
-{{path-abandon-close}}). Note that while abandoning a path implies
+{{path-abandon-close}}). Note that while abandoning a path will cause
 Connection ID retirement, only retiring the associated Connection ID
 does not necessarily advertise path abandon (see {{retire-cid-close}}).
 However, implicit signals such as idle time or packet losses might be


### PR DESCRIPTION
Minor tweak. The text says that a path abandon "implies" retirement of the CID. Readers could be mislead and assume that they don't need to send a retire frame after sending abandon, when in fact they do.