### PR TITLE
[~] Receiving old packet number space identifier in ACK_MP

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1147,9 +1147,13 @@ space, which is the sequence number of Destination Connection ID of
 the 1-RTT packets which are acknowledged by the ACK_MP frame.
 If the endpoint receives 1-RTT packets with zero-length Connection ID,
 it SHOULD use Packet Number Space Identifier 0 in ACK_MP frames.
-If an endpoint receives an ACK_MP frame with a non-existing packet number
-space ID, it MUST treat this as a connection error of type
-MP_PROTOCOL_VIOLATION and close the connection.
+If an endpoint receives an ACK_MP frame with a packet number
+space ID which is never issued by endpoints, it MUST treat this as
+a connection error of type MP_PROTOCOL_VIOLATION and close the connection.
+If an endpoint receives an ACK_MP frame with a packet number space ID
+which is retired by RETIRE_CONNECTION_ID frame or closed paths, it SHOULD
+ignore the ACK_MP frame without causing a connection error.
+
 
 When using a single packet number space, endhosts MUST NOT send ACK_MP frames.
 If an endhost receives an ACK_MP frame while a single packet number space
@@ -1221,3 +1225,4 @@ one of the original proposals are:
 # Acknowledgments
 
 TBD
+f


### PR DESCRIPTION
Fix issue #128 