### PR TITLE
Clarifications on connection migration

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -894,7 +894,7 @@ In this case the server performs path validation (see {{Section 9 of QUIC-TRANSP
 Moreover, {{Section 5.1.2 of QUIC-TRANSPORT}} indicates that an endpoint
 can change the connection ID it uses for a peer to another available one
 at any time during the connection. As such a sole change of the Connection
-ID without any change in the address does indiacte a path. 
+ID without any change in the address does not indicate a new change. 
 
 If an endpoint uses a new Connection ID after an idle period
 and a NAT binding leads to a 4-tuple changes on the same packet,

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -912,7 +912,7 @@ the receiving endpoint may not be able to associate the packet to
 an existing path and will therefore consider this as a new path.
 This leads to an inconsistent view of open paths at both peers,
 however, as the "old" path will not work anymore, it will be silently
-closed after the idle timeout expires. 
+closed after the idle timeout expires.
 
 
 # New Frames {#frames}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -897,7 +897,7 @@ networks events such as NAT rebinding may make the packet's receiver
 observe a different 4-tuple. Servers observing a 4-tuple change will
 performs path validation (see {{Section 9 of QUIC-TRANSPORT}}).
 If the path validation process succeeds, the endpoints need to reset
-their congestion controller and round-trip time estimator for he new
+their congestion controller and round-trip time estimator for the new
 path as specficied in  {{Section 9.4 of QUIC-TRANSPORT}}.
 
 {{Section 9.3 of QUIC-TRANSPORT}} allows an endpoint to skip validation of

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -885,6 +885,37 @@ two or more active paths during the connection lifetime. Different applications 
 Once the implementation has decided which paths to keep alive, it can do so by sending Ping frames
 on each of these paths before the idle timeout expires.
 
+## Migration
+
+Even when the multipath extension is used, migration can happen.
+E.g. the client's source port and/or IP address may change due to changes
+in network topology or address mappings, such as caused by NAT rebinding.
+In this case the server performs path validation (see {{Section 9 of QUIC-TRANSPORT}}
+and both peers are expected to use new connection IDs during this process.
+
+Even is the path validation is causes by a migration event, when
+the multipath extension is used, the
+endpoint treats the receipt of a PATH_CHALLENGE frame as a new path
+and also initiates path validation to open the path.
+This is important to ensure
+that both peers have the same view on the number of active paths. However,
+this also implicitly means that every migration event will cause a congestion
+control reset, even if e.g. only the source port changed. Further, if the
+old path after a migration event is not usable anymore, with the multipath
+extension the endpoint might send a PATH_ABANDON frame to close the path.
+
+{{Section 9.3 of QUIC-TRANSPORT}} allows an endpoint to skip validation of
+a peer address if that address has been seen recently. However, when the
+multipath extension is used and an endpoint has multiple addresses that
+could lead to switching between different paths, it should rather maintain
+multiple open paths instead. Otherwise switching paths without path validation
+could cause an inconsistent view of open paths at both peer.
+
+Moreover, {{Section 5.1.2 of QUIC-TRANSPORT}} indicates that an endpoint
+can change the connection ID it uses for a peer to another available one
+at any time during the connection. As such a sole change of the Connection
+ID without any change in the address does open a new path.
+
 # New Frames {#frames}
 
 All the new frames MUST only be sent in 1-RTT packet, and MUST NOT

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -884,31 +884,35 @@ two or more active paths during the connection lifetime. Different applications 
 Once the implementation has decided which paths to keep alive, it can do so by sending Ping frames
 on each of these paths before the idle timeout expires.
 
-## Migration
+## Connection ID Changes and NAT Rebindings
 
-Even when the multipath extension is used, migration can happen.
-E.g. the client's source port and/or IP address may change due to changes
-in network topology or address mappings, such as caused by NAT rebinding.
-In this case the server performs path validation (see {{Section 9 of QUIC-TRANSPORT}}).
-
-Moreover, {{Section 5.1.2 of QUIC-TRANSPORT}} indicates that an endpoint
-can change the connection ID it uses for a peer to another available one
+{{Section 5.1.2 of QUIC-TRANSPORT}} indicates that an endpoint
+can change the connection ID it uses for to another available one
 at any time during the connection. As such a sole change of the Connection
-ID without any change in the address does not indicate a new change. 
+ID without any change in the address does not indicate a path change and
+the endpoint will keep the same congestion control and RTT measurement state.
 
-If an endpoint uses a new Connection ID after an idle period
-and a NAT binding leads to a 4-tuple changes on the same packet,
-the receiving endpoint may not be able to associate the packet to
-an existing path and will therefore consider this as a new path.
-This leads to an inconsistent view of open paths at both peers,
-however, as the "old" path will not work anymore, it will be silently
-closed after the idle timeout expires. 
+While endpoints assign a Connection ID to a specific sending 4-tuple,
+networks events such as NAT rebinding may make the packet's receiver
+observe a different 4-tuple. Servers observing a 4-tuple change will
+performs path validation (see {{Section 9 of QUIC-TRANSPORT}}).
+If the path validation process succeeds, the endpoints need to reset
+their congestion controller and round-trip time estimator for he new
+path as specficied in  {{Section 9.4 of QUIC-TRANSPORT}}.
 
 {{Section 9.3 of QUIC-TRANSPORT}} allows an endpoint to skip validation of
 a peer address if that address has been seen recently. However, when the
 multipath extension is used and an endpoint has multiple addresses that
 could lead to switching between different paths, it should rather maintain
 multiple open paths instead.
+
+If an endpoint uses a new Connection ID after an idle period
+and a NAT rebinding leads to a 4-tuple changes on the same packet,
+the receiving endpoint may not be able to associate the packet to
+an existing path and will therefore consider this as a new path.
+This leads to an inconsistent view of open paths at both peers,
+however, as the "old" path will not work anymore, it will be silently
+closed after the idle timeout expires. 
 
 
 # New Frames {#frames}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -890,10 +890,10 @@ on each of these paths before the idle timeout expires.
 Even when the multipath extension is used, migration can happen.
 E.g. the client's source port and/or IP address may change due to changes
 in network topology or address mappings, such as caused by NAT rebinding.
-In this case the server performs path validation (see {{Section 9 of QUIC-TRANSPORT}}
+In this case the server performs path validation (see {{Section 9 of QUIC-TRANSPORT}})
 and both peers are expected to use new connection IDs during this process.
 
-Even is the path validation is causes by a migration event, when
+Even is the path validation is caused by a migration event, when
 the multipath extension is used, the
 endpoint treats the receipt of a PATH_CHALLENGE frame as a new path
 and also initiates path validation to open the path.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -110,8 +110,7 @@ Connection IDs in both directions.
 address as well as source and destination port. Therefore, there can be
 at most one active paths/connection ID per 4-tuple.
   * If the 4-tuple changes without the use of a new connection ID (e.g.
-due to a NAT rebinding), this is considered as a migration event and not
-as a new path.
+due to a NAT rebinding), this is considered as a migration event.
 
 The path management specified in {{Section 9 of QUIC-TRANSPORT}}
 fulfills multiple goals: it directs a peer to switch sending through

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -889,31 +889,27 @@ on each of these paths before the idle timeout expires.
 Even when the multipath extension is used, migration can happen.
 E.g. the client's source port and/or IP address may change due to changes
 in network topology or address mappings, such as caused by NAT rebinding.
-In this case the server performs path validation (see {{Section 9 of QUIC-TRANSPORT}})
-and both peers are expected to use new connection IDs during this process.
+In this case the server performs path validation (see {{Section 9 of QUIC-TRANSPORT}}).
 
-Even is the path validation is caused by a migration event, when
-the multipath extension is used, the
-endpoint treats the receipt of a PATH_CHALLENGE frame as a new path
-and also initiates path validation to open the path.
-This is important to ensure
-that both peers have the same view on the number of active paths. However,
-this also implicitly means that every migration event will cause a congestion
-control reset, even if e.g. only the source port changed. Further, if the
-old path after a migration event is not usable anymore, with the multipath
-extension the endpoint might send a PATH_ABANDON frame to close the path.
+Moreover, {{Section 5.1.2 of QUIC-TRANSPORT}} indicates that an endpoint
+can change the connection ID it uses for a peer to another available one
+at any time during the connection. As such a sole change of the Connection
+ID without any change in the address does indiacte a path. 
+
+If an endpoint uses a new Connection ID after an idle period
+and a NAT binding leads to a 4-tuple changes on the same packet,
+the receiving endpoint may not be able to associate the packet to
+an existing path and will therefore consider this as a new path.
+This leads to an inconsistent view of open paths at both peers,
+however, as the "old" path will not work anymore, it will be silently
+closed after the idle timeout expires. 
 
 {{Section 9.3 of QUIC-TRANSPORT}} allows an endpoint to skip validation of
 a peer address if that address has been seen recently. However, when the
 multipath extension is used and an endpoint has multiple addresses that
 could lead to switching between different paths, it should rather maintain
-multiple open paths instead. Otherwise switching paths without path validation
-could cause an inconsistent view of open paths at both peer.
+multiple open paths instead.
 
-Moreover, {{Section 5.1.2 of QUIC-TRANSPORT}} indicates that an endpoint
-can change the connection ID it uses for a peer to another available one
-at any time during the connection. As such a sole change of the Connection
-ID without any change in the address does open a new path.
 
 # New Frames {#frames}
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -890,15 +890,15 @@ on each of these paths before the idle timeout expires.
 can change the Connection ID it uses for to another available one
 at any time during the connection. As such a sole change of the Connection
 ID without any change in the address does not indicate a path change and
-the endpoint will keep the same congestion control and RTT measurement state.
+the endpoint can keep the same congestion control and RTT measurement state.
 
 While endpoints assign a Connection ID to a specific sending 4-tuple,
 networks events such as NAT rebinding may make the packet's receiver
 observe a different 4-tuple. Servers observing a 4-tuple change will
 performs path validation (see {{Section 9 of QUIC-TRANSPORT}}).
-If the path validation process succeeds, the endpoints need to reset
-their congestion controller and round-trip time estimator for the new
-path as specficied in  {{Section 9.4 of QUIC-TRANSPORT}}.
+If path validation process succeeds, the endpoints set
+the path's congestion controller and round-trip time
+estimator according to {{Section 9.4 of QUIC-TRANSPORT}}.
 
 {{Section 9.3 of QUIC-TRANSPORT}} allows an endpoint to skip validation of
 a peer address if that address has been seen recently. However, when the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -887,7 +887,7 @@ on each of these paths before the idle timeout expires.
 ## Connection ID Changes and NAT Rebindings
 
 {{Section 5.1.2 of QUIC-TRANSPORT}} indicates that an endpoint
-can change the connection ID it uses for to another available one
+can change the Connection ID it uses for to another available one
 at any time during the connection. As such a sole change of the Connection
 ID without any change in the address does not indicate a path change and
 the endpoint will keep the same congestion control and RTT measurement state.


### PR DESCRIPTION
fixes #160

As I added this text into the implementation consideration section, I on purpose did not use normative language. However, we might want to double check that the normative language we used elsewhere in the document is covering this appropriately.