### PR TITLE
Clarify path close and waiting for at least 3 PTOs

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -384,9 +384,6 @@ Both endpoints, namely the client and the server, can close a path,
 by sending PATH_ABANDON frame (see {{path-abandon-frame}}) which
 abandons the path with a corresponding Path Identifier.
 
-The endpoint sending the PATH_ABANDON frame can consider a path as
-abandoned when the packet that contained the PATH_ABANDON frame is
-acknowledged.
 
 The receiver of a PATH_ABANDON frame should not release its resources
 immediately, but SHOULD wait for at least three times the current

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -398,7 +398,7 @@ if any.
 
 The receiver of a PATH_ABANDON frame SHOULD NOT release its resources
 immediately, but SHOULD wait for the reception of the RETIRE_CONNECTION_ID
-frame for the used connection IDs but at least three times the current 
+frame for the used connection IDs but at least three times the current
 Probe Timeout (PTO) interval as defined in {{Section 6.2. of QUIC-RECOVERY}}.
 This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
 to ensure that paths close cleanly and that delayed or reordered packets

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -391,7 +391,7 @@ acknowledged.
 The receiver of a PATH_ABANDON frame SHOULD NOT release its resources
 immediately, but SHOULD wait for at least three times the current
 Probe Timeout (PTO) interval as defined in {{Section 6.2. of QUIC-RECOVERY}}
-after the last time a packet with the corresponding CID or until it receives
+after receive of the PATH_ABANDON frame or until it receives
 a RETIRE_CONNECTION_ID frame for that CID, whichever happens sooner.
 
 Similarly, an endpoint SHOULD wait for three PTOs after the last sent packet

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -53,11 +53,11 @@ normative:
   RFC2119:
   QUIC-TRANSPORT: rfc9000
   QUIC-TLS: rfc9001
+  QUIC-RECOVERY: rfc9002
 
 informative:
   RFC6356:
   I-D.bonaventure-iccrg-schedulers:
-  QUIC-RECOVERY: rfc9002
   QUIC-Invariants: rfc8999
   QUIC-Timestamp: I-D.huitema-quic-ts
   OLIA:
@@ -398,7 +398,11 @@ if any.
 
 The receiver of a PATH_ABANDON frame SHOULD NOT release its resources
 immediately, but SHOULD wait for the reception of the RETIRE_CONNECTION_ID
-frame for the used connection IDs or 3 RTOs.
+frame for the used connection IDs but at least three times the current 
+Probe Timeout (PTO) interval as defined in {{Section 6.2. of QUIC-RECOVERY}}.
+This is inline with the requirement of {{Sectuion 10.2 of QUIC-TRANSPORT}}
+to ensure that paths close cleanly and that delayed or reordered packets
+are properly discarded.
 
 Usually, it is expected that the PATH_ABANDON frame is used by the client
 to indicate to the server that path conditions have changed such that
@@ -430,7 +434,7 @@ and enters the closing state. If the client received a PATH_ABANDON
 frame for the last open path, it MAY instead try to open a new path, if
 available, and only initiate connection closure if path validation fails
 or a CONNECTION_CLOSE frame is received from the server. Similarly
-the server MAY wait for a short, limited time such as one RTO if a path
+the server MAY wait for a short, limited time such as one PTO if a path
 probing packet is received on a new path before sending the
 CONNECTION_CLOSE frame.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -400,7 +400,7 @@ The receiver of a PATH_ABANDON frame SHOULD NOT release its resources
 immediately, but SHOULD wait for the reception of the RETIRE_CONNECTION_ID
 frame for the used connection IDs but at least three times the current 
 Probe Timeout (PTO) interval as defined in {{Section 6.2. of QUIC-RECOVERY}}.
-This is inline with the requirement of {{Sectuion 10.2 of QUIC-TRANSPORT}}
+This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -388,17 +388,16 @@ The endpoint sending the PATH_ABANDON frame can consider a path as
 abandoned when the packet that contained the PATH_ABANDON frame is
 acknowledged.
 
-The receiver of a PATH_ABANDON frame SHOULD NOT release its resources
+The receiver of a PATH_ABANDON frame should not release its resources
 immediately, but SHOULD wait for at least three times the current
 Probe Timeout (PTO) interval as defined in {{Section 6.2. of QUIC-RECOVERY}}
-after receive of the PATH_ABANDON frame or until it receives
-a RETIRE_CONNECTION_ID frame for that CID, whichever happens sooner.
-
-Similarly, an endpoint SHOULD wait for three PTOs after the last sent packet
-before sending the RETIRE_CONNECTION_ID frame for the corresponding CID.
+after the last sent packet before sending the RETIRE_CONNECTION_ID frame
+for the corresponding CID.
 This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.
+The effect of receiving a RETIRE_CONNECTION_ID frame is specified in the
+next section.
 
 Usually, it is expected that the PATH_ABANDON frame is used by the client
 to indicate to the server that path conditions have changed such that

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -405,7 +405,7 @@ the path is or will be not usable anymore, e.g. in case of a mobility
 event. The PATH_ABANDON frame therefore recommends to the receiver
 that no packets should be sent on that path anymore.
 In addition, the RETIRE_CONNECTION_ID frame is used indicate to the receiving peer
-that the sender does not intend to send any packets assiciated to the
+that the sender will not send any packets associated to the
 Connection ID used on that path anymore.
 The receiver of an PATH_ABANDON frame MAY also send
 an PATH_ABANDON frame to indicate its own unwillingness to receive

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -373,7 +373,7 @@ Both endpoints, namely the client and the server, can initiate path closure,
 by sending a PATH_ABANDON frame (see {{path-abandon-frame}}) which
 requests the peer to stop sending packets with the corresponding Destination Connection ID.
 
-The receiver of a PATH_ABANDON frame should not release its resources
+The sender and receiver of a PATH_ABANDON frame should not release its resources
 immediately, but SHOULD wait for at least three times the current
 Probe Timeout (PTO) interval as defined in {{Section 6.2. of QUIC-RECOVERY}}
 after the last sent packet before sending the RETIRE_CONNECTION_ID frame

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -407,8 +407,8 @@ that no packets should be sent on that path anymore.
 In addition, the RETIRE_CONNECTION_ID frame is used indicate to the receiving peer
 that the sender will not send any packets associated to the
 Connection ID used on that path anymore.
-The receiver of an PATH_ABANDON frame MAY also send
-an PATH_ABANDON frame to indicate its own unwillingness to receive
+The receiver of a PATH_ABANDON frame MAY also send
+a PATH_ABANDON frame to indicate its own unwillingness to receive
 any packet on this path anymore.
 
 PATH_ABANDON frames can be sent on any path,


### PR DESCRIPTION
The current text says that one has to wait for a the retire frame or 3 PTOs. However (as also indicated in the states figure) this should be at least 3 PTOs. This PR fixes this inconsistency. Further is add a reference to the definition to PTO and replaces RTO with PTO where the wrong term is used. I believe all these fixes address straightforward mistakes, however, if discussion is needed, we can of course also open an issue.