### PR TITLE
Remove mentions of the "Path Identifier"

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -206,7 +206,7 @@ In this version of the document, a QUIC server does not initiate the creation
 of a path, but it can validate a new path created by a client.
 A new path can only be used once the associated 4-tuple has been validated
 by ensuring that the peer is able to receive packets at that address
-(see {{Section 8 of RFC9000}}). The Destination Connection ID is used
+(see {{Section 8 of QUIC-TRANSPORT}}). The Destination Connection ID is used
 to associate a packet to a packet number space that is used on a valid path. Further, the
 sequence number of Destination Connection ID is used as numerical identifier
 in control frames. E.g. an endpoint sends a PATH_ABANDON frame to request its peer to

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -204,10 +204,10 @@ To add a new path to an existing multipath QUIC connection, a client starts a pa
 the chosen path, as further described in {{setup}}.
 In this version of the document, a QUIC server does not initiate the creation
 of a path, but it can validate a new path created by a client.
-A new path can only be used once it has been validated. Each endpoint
-identifies its paths by the sequence number of the Destination
-Connection ID it uses over them. Such numerical identifier is notably
-used when an endpoint sends a PATH_ABANDON frame to request its peer to
+A new path can only be used once it has been validated. The Destination
+Connection ID is used to associate a packet to a valid path. Further, the
+sequence number of Destination Connection ID is used as numerical identifier
+in control frames. E.g. an endpoint sends a PATH_ABANDON frame to request its peer to
 abandon the path on which the sender uses the Destination Connection ID
 with the sequence number contained in the PATH_ABANDON frame.
 
@@ -580,8 +580,7 @@ The ACK_MP frame, as specified in {{ack-mp-frame}}, is used to
 acknowledge 1-RTT packets.
 Compared to the QUIC version 1 ACK frame, the ACK_MP frame additionally
 contains the Receiver's Destination Connection ID Sequence Number field
-to distinguish the Connection ID-specific packet number space
-acknowledged.
+to distinguish the Connection ID-specific packet number space.
 
 Acknowledgements of Initial and Handshake packets MUST be carried using
 ACK frames, as specified in {{QUIC-TRANSPORT}}. The ACK frames, as defined
@@ -592,7 +591,7 @@ the Connection ID having sequence number 0.
 
 As soon as the negotiation of multipath support is completed,
 endpoints SHOULD use ACK_MP frames instead of ACK frames to acknowledge application
-data packets, including 0-RTT packets, using the Connection ID with
+data packets, including 0-RTT packets, using the initial Connection ID with
 sequence number 0 after the handshake concluded.
 
 ACK_MP frame (defined in {{ack-mp-frame}}) SHOULD be sent on the path
@@ -961,7 +960,7 @@ PATH_STATUS Frames contain the following fields:
 Sender's Destination Connection ID Sequence Number:
 : The sequence number of the Destination Connection ID used by the
   sender of this frame to send packets over the path the status update
-  corresponds.
+  corresponds to.
 
 Path Status sequence number:
 : A variable-length integer specifying

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -539,7 +539,7 @@ In Active state, hosts MUST also track the following information:
 
 - Associated Source Connection ID: The Connection ID used to receive
 packets over the path. The endpoint relies on its sequence number to
-receive and acknowledge packets belonging to that Connection ID-specific
+send path control information and specifically acknowledge packets belonging to that Connection ID-specific
 packet number space.
 
 A path in the "Validating" state performs path validation as described

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -340,8 +340,8 @@ PATH_STATUS frame describes 2 kinds of path states:
 - Mark a path as "standby", i.e., suggest that no traffic should be sent
   on that path if another path is available.
 
-Endpoints use Sender's Destination Connection ID Sequence Number field
-in PATH_STATUS frame to identify which path’s state is going to be
+Endpoints use Destination Connection ID Sequence Number field
+in PATH_STATUS frame to identify which path state is going to be
 changed. Notice that PATH_STATUS frame
 can be sent via a different path. An Endpoint MAY ignore the PATH_STATUS frame
 if it would make all the paths unavailable in a single connection.
@@ -375,7 +375,7 @@ Reset ({{Section 10.3 of QUIC-TRANSPORT}}) closes the connection.
 Both endpoints, namely the client and the server, can close a path,
 by sending PATH_ABANDON frame (see {{path-abandon-frame}}) which
 abandons the path with the corresponding Destination Connection ID.
-The PATH_ABANDON frame contains the Sender's Destination Connection
+The PATH_ABANDON frame contains the Destination Connection
 ID Sequence Number and therefore can be sent on any path.
 
 Once a path is
@@ -575,13 +575,13 @@ the ACK frame as well as packet protection as described in the following subsect
 The ACK_MP frame, as specified in {{ack-mp-frame}}, is used to
 acknowledge 1-RTT packets.
 Compared to the QUIC version 1 ACK frame, the ACK_MP frame additionally
-contains the Receiver's Destination Connection ID Sequence Number field
+contains the receiver's Destination Connection ID Sequence Number field
 to distinguish the Connection ID-specific packet number space.
 
 Acknowledgements of Initial and Handshake packets MUST be carried using
 ACK frames, as specified in {{QUIC-TRANSPORT}}. The ACK frames, as defined
-in {{QUIC-TRANSPORT}}, do not carry the Receiver's Destination
-Connection ID Sequence Number field. If multipath has been successfully
+in {{QUIC-TRANSPORT}}, do not carry the Destination Connection ID
+Sequence Number field. If multipath has been successfully
 negotiated, ACK frames in 1-RTT packets acknowledge packets sent with
 the Connection ID having sequence number 0.
 
@@ -728,11 +728,12 @@ second path, the server's 1-RTT packets use DCID C2, which has a sequence
 number of 2; the client's 1-RTT packets use DCID S3, which has a sequence number
 of 3. Note that the paths use different packet number spaces. In this case, the
 client is going to close the first path. It identifies the path by the sequence
-number of the DCID it uses for sending packets over that path,
-hence using the path_id 2. Optionally, the server confirms the path closure
+number of the DCID its peer uses for sending packets over that path,
+hence using the DCID sequence number 1 (which relates to C1). Optionally, the
+server confirms the path closure
 by sending an PATH_ABANDON frame by indicating the sequence number of the DCID
-it uses to send over that path, which corresponds to the sequence number
-1 (of C1). Both the client and
+the client uses to send over that path, which corresponds to the sequence number
+2 (of S2). Both the client and
 the server can close the path after receiving the RETIRE_CONNECTION_ID frame
 for that path.
 
@@ -740,9 +741,9 @@ for that path.
 Client                                                      Server
 
 (client tells server to abandon a path)
-1-RTT[X]: DCID=S2 PATH_ABANDON[sender_dcid_seq_num=2]->
+1-RTT[X]: DCID=S2 PATH_ABANDON[dcid_seq_num=1]->
                            (server tells client to abandon a path)
-               <-1-RTT[Y]: DCID=C1 PATH_ABANDON[sender_dcid_seq_num=1],
+               <-1-RTT[Y]: DCID=C1 PATH_ABANDON[dcid_seq_num=2],
                                                ACK_MP[PID=2, PN=X]
 (client retires the corresponding CID)
 1-RTT[U]: DCID=S3 RETIRE_CONNECTION_ID[2], ACK_MP[PID=1, PN=Y] ->
@@ -895,7 +896,7 @@ PATH_ABANDON frames are formatted as shown in {{fig-path-abandon-format}}.
 ~~~
   PATH_ABANDON Frame {
     Type (i) = TBD-02 (experiments use 0xbaba05),
-    Sender's Destination Connection ID Sequence Number (i),
+    Destination Connection ID Sequence Number (i),
     Error Code (i),
     Reason Phrase Length (i),
     Reason Phrase (..),
@@ -905,9 +906,9 @@ PATH_ABANDON frames are formatted as shown in {{fig-path-abandon-format}}.
 
 PATH_ABANDON frames contain the following fields:
 
-Sender's Destination Connection ID Sequence Number:
+Destination Connection ID Sequence Number:
 : The sequence number of the Destination Connection ID used by the
-  sender of this frame to send packets over the path to abandon.
+  receiver of the frame to send packets over the path to abandon.
 
 Error Code:
 : A variable-length integer that indicates the reason for abandoning
@@ -944,7 +945,7 @@ PATH_STATUS frames are formatted as shown in {{fig-path-status-format}}.
 ~~~
   PATH_STATUS Frame {
     Type (i) = TBD-03 (experiments use 0xbaba06),
-    Sender's Destination Connection ID Sequence Number (i),
+    Destination Connection ID Sequence Number (i),
     Path Status sequence number (i),
     Path Status (i),
   }
@@ -953,9 +954,9 @@ PATH_STATUS frames are formatted as shown in {{fig-path-status-format}}.
 
 PATH_STATUS Frames contain the following fields:
 
-Sender's Destination Connection ID Sequence Number:
+Destination Connection ID Sequence Number:
 : The sequence number of the Destination Connection ID used by the
-  sender of this frame to send packets over the path the status update
+  receiver of this frame to send packets over the path the status update
   corresponds to.
 
 Path Status sequence number:
@@ -964,7 +965,7 @@ Path Status sequence number:
   number MUST be monotonically increasing generated by the sender of
   the PATH_STATUS frame in the same connection. The receiver of
   the PATH_STATUS frame needs to use and compare the sequence numbers
-  separately for each Sender's Destination Connection ID Sequence
+  separately for each Destination Connection ID Sequence
   Number.
 
 Available values of Path Status field are:
@@ -981,7 +982,7 @@ the same path.
 
 Frames may be received out of order. A peer MUST ignore an incoming
 PATH_STATUS frame if it previously received another PATH_STATUS frame
-for the same Sender's Destination Connection ID Sequence Number with a
+for the same Destination Connection ID Sequence Number with a
 Path Status sequence number equal to or higher than the Path Status
 sequence number of the incoming frame.
 
@@ -1005,7 +1006,7 @@ ACK_MP frame is formatted as shown in {{fig-ack-mp-format}}.
 ~~~
   ACK_MP Frame {
     Type (i) = TBD-00..TBD-01 (experiments use 0xbaba00..0xbaba01),
-    Receiver's Destination Connection ID Sequence Number (i),
+    Destination Connection ID Sequence Number (i),
     Largest Acknowledged (i),
     ACK Delay (i),
     ACK Range Count (i),
@@ -1019,7 +1020,7 @@ ACK_MP frame is formatted as shown in {{fig-ack-mp-format}}.
 Compared to the ACK frame specified in {{QUIC-TRANSPORT}}, the following
 field is added.
 
-Receiver's Destination Connection ID Sequence Number:
+Destination Connection ID Sequence Number:
 : The sequence number of the Connection ID identifying the packet number
   space of the 1-RTT packets which are acknowledged by the ACK_MP frame.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -508,7 +508,7 @@ after a spurious estimate of path abandonment by the client.
  |   Active   |----------------------------------+
  +------------+                                  |
        |                                         |
-       | PATH_ABANDONED sent/received            |
+       | PATH_ABANDON sent/received              |
        v                                         |
  +------------+                                  |
  |   Closing  |                                  |
@@ -546,12 +546,12 @@ guarantee that packets will actually reach the peer.
 The endhost can use all the paths in the "Active" state, provided
 that the congestion control and flow control currently allow sending
 of new data on a path. Note that if a path became idle due to a timeout,
-endpoints SHOULD send PATH_ABANDONED frame before closing the path.
+endpoints SHOULD send PATH_ABANDON frame before closing the path.
 
 In the "Closing" state, the endhost SHOULD NOT send packets on this
 path anymore, as there is no guarantee that the peer can still map
 the packets to the connection. The endhost SHOULD wait for
-the acknowledgment of the PATH_ABANDONED frame before moving the path
+the acknowledgment of the PATH_ABANDON frame before moving the path
 to the "Closed" state to ensure a graceful termination of the path.
 
 When a path reaches the "Closed" state, the endhost releases all the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -204,8 +204,10 @@ To add a new path to an existing multipath QUIC connection, a client starts a pa
 the chosen path, as further described in {{setup}}.
 In this version of the document, a QUIC server does not initiate the creation
 of a path, but it can validate a new path created by a client.
-A new path can only be used once it has been validated. The Destination
-Connection ID is used to associate a packet to a valid path. Further, the
+A new path can only be used once the associated 4-tuple has been validated
+by ensuring that the peer is able to receive packets at that address
+(see {{Section 8 of RFC9000}}). The Destination Connection ID is used
+to associate a packet to a packet number space that is used on a valid path. Further, the
 sequence number of Destination Connection ID is used as numerical identifier
 in control frames. E.g. an endpoint sends a PATH_ABANDON frame to request its peer to
 abandon the path on which the sender uses the Destination Connection ID
@@ -372,9 +374,9 @@ Reset ({{Section 10.3 of QUIC-TRANSPORT}}) closes the connection.
 
 ### Use PATH_ABANDON Frame to Close a Path {#path-abandon-close}
 
-Both endpoints, namely the client and the server, can close a path,
+Both endpoints, namely the client and the server, can initiate path closure,
 by sending PATH_ABANDON frame (see {{path-abandon-frame}}) which
-abandons the path with the corresponding Destination Connection ID.
+which requests the peer to stop sending packets with the corresponding Destination Connection ID.
 The PATH_ABANDON frame contains the Destination Connection
 ID Sequence Number and therefore can be sent on any path.
 
@@ -581,7 +583,8 @@ to distinguish the Connection ID-specific packet number space.
 Acknowledgements of Initial and Handshake packets MUST be carried using
 ACK frames, as specified in {{QUIC-TRANSPORT}}. The ACK frames, as defined
 in {{QUIC-TRANSPORT}}, do not carry the Destination Connection ID
-Sequence Number field. If multipath has been successfully
+Sequence Number field to identify the packet number space.
+If the multipath extension has been successfully
 negotiated, ACK frames in 1-RTT packets acknowledge packets sent with
 the Connection ID having sequence number 0.
 
@@ -591,7 +594,7 @@ data packets, including 0-RTT packets, using the initial Connection ID with
 sequence number 0 after the handshake concluded.
 
 ACK_MP frame (defined in {{ack-mp-frame}}) SHOULD be sent on the path
-it perceives the Connection ID of the packet number space it acknowledges.
+it received packet with the Connection ID of the packet number space it acknowledges.
 However, an ACK_MP frame can be returned via a
 different path, based on different strategies of sending ACK_MP frames.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -747,7 +747,7 @@ Client                                                      Server
 (client tells server to abandon a path)
 1-RTT[X]: DCID=S2 PATH_ABANDON[sender_dcid_seq_num=2]->
                            (server tells client to abandon a path)
-                      <-1-RTT[Y]: DCID=C1 PATH_ABANDON[sender_dcid_seq_num=1],
+               <-1-RTT[Y]: DCID=C1 PATH_ABANDON[sender_dcid_seq_num=1],
                                                ACK_MP[PID=2, PN=X]
 (client retires the corresponding CID)
 1-RTT[U]: DCID=S3 RETIRE_CONNECTION_ID[2], ACK_MP[PID=1, PN=Y] ->
@@ -1028,7 +1028,7 @@ Receiver's Destination Connection ID Sequence Number:
 : The sequence number of the Connection ID identifying the packet number
   space of the 1-RTT packets which are acknowledged by the ACK_MP frame.
 
-If an endpoint receives an ACK_MP frame with a Connection ID sequence 
+If an endpoint receives an ACK_MP frame with a Connection ID sequence
 number which was never issued (i.e., with a sequence number
 larger than the largest one advertised), it MUST treat this as a connection
 error of type MP_PROTOCOL_VIOLATION and close the connection.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -529,11 +529,7 @@ In non-final states, hosts have to track the following information.
 destination port) used by the endhost to send packets over the path.
 
 - Associated Destination Connection ID: The Connection ID used to send
-packets over the path. The endpoint relies on its sequence number to
-maintain a Destination Connection ID-specific packet number space for
-sending packets over this path. Packet number considerations as
-described in {{Section 12.3 of QUIC-TRANSPORT}} apply within the given
-path.
+packets over the path.
 
 In Active state, hosts MUST also track the following information:
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1028,10 +1028,6 @@ If an endpoint receives an ACK_MP frame with a Connection ID sequence
 number which was never issued (i.e., with a sequence number
 larger than the largest one advertised), it MUST treat this as a connection
 error of type MP_PROTOCOL_VIOLATION and close the connection.
-If an endpoint receives an ACK_MP frame with a Connection ID sequence
-number which is no more active (e.g., retired by a RETIRE_CONNECTION_ID
-frame or belonging to closed paths), it MUST ignore the ACK_MP frame
-without causing a connection error.
 
 
 # Error Codes {#error-codes}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -375,8 +375,8 @@ Reset ({{Section 10.3 of QUIC-TRANSPORT}}) closes the connection.
 ### Use PATH_ABANDON Frame to Close a Path {#path-abandon-close}
 
 Both endpoints, namely the client and the server, can initiate path closure,
-by sending PATH_ABANDON frame (see {{path-abandon-frame}}) which
-which requests the peer to stop sending packets with the corresponding Destination Connection ID.
+by sending a PATH_ABANDON frame (see {{path-abandon-frame}}) which
+requests the peer to stop sending packets with the corresponding Destination Connection ID.
 The PATH_ABANDON frame contains the Destination Connection
 ID Sequence Number and therefore can be sent on any path.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -176,13 +176,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 capitals, as shown here.
 
 We assume that the reader is familiar with the terminology used in
-{{QUIC-TRANSPORT}}. In addition, we define the following term:
-
-- Path: refers to the 4-tuple {source IP address, source port number,
-  destination IP address, destination port number}. A path refers to
-  "network path" used in {{QUIC-TRANSPORT}}. Endpoints identify a path
-  by the sequence number of the Destination Connection ID they use over
-  that path.
+{{QUIC-TRANSPORT}}. When this document uses the term "path", it refers
+to the notion of "network path" used in {{QUIC-TRANSPORT}}.
 
 # High-level overview {#overview}
 


### PR DESCRIPTION
In lot of places in the draft, we mention the "Path Identifier", which we define as the Destination Connection ID sequence number used over that path. It seems that maintaining the notion of "Path Identifier" causes a lot of confusion, so better keep things simple and mention CID sequence numbers directly.

Note that this implies that the related fields in
multipath-specific have been renamed to their "explicit" form. Some of these names are maybe a bit long, so we may shorten them if this does not introduce ambiguity.

Fix #169. Rewriting related section may also answer #181.