### PR TITLE
Add descriptions on resetting packet number  when a new CID is used

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -582,6 +582,13 @@ This also means that the same packet number can occur on each path and the
 packet number is not a unique identifier anymore. This requires changes to
 the ACK frame as well as packet protection as described in the following subsections.
 
+When multipath is negotiated,
+each destination connection ID is linked to a separate packet number space.
+When an existing path switches to a new CID or a new CID is used to open a new path,
+the largest packet number (largest_acked) that has been acknowledged by the
+peer in this new CID's packet number space SHOULD be reset to "None"
+for packet number encodings, as specified in ({{Section A.2 of QUIC-TRANSPORT}}).
+
 ## Sending Acknowledgements
 
 The ACK_MP frame, as specified in {{ack-mp-frame}}, is used to

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -584,10 +584,10 @@ the ACK frame as well as packet protection as described in the following subsect
 
 When multipath is negotiated,
 each Destination Connection ID is linked to a separate packet number space.
-When an existing path switches to a new CID or a new CID is used to open a new path,
+Each CID-specific packet number space starts at packet number 0. When following
+the packet number encoding algorithm described in {{Section A.2 of QUIC-TRANSPORT}},
 the largest packet number (largest_acked) that has been acknowledged by the
-peer in this new CID's packet number space SHOULD be reset to "None"
-for packet number encodings, as specified in ({{Section A.2 of QUIC-TRANSPORT}}).
+peer in this new CID's packet number space is initially set to "None".
 
 ## Sending Acknowledgements
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -583,7 +583,7 @@ packet number is not a unique identifier anymore. This requires changes to
 the ACK frame as well as packet protection as described in the following subsections.
 
 When multipath is negotiated,
-each destination connection ID is linked to a separate packet number space.
+each Destination Connection ID is linked to a separate packet number space.
 When an existing path switches to a new CID or a new CID is used to open a new path,
 the largest packet number (largest_acked) that has been acknowledged by the
 peer in this new CID's packet number space SHOULD be reset to "None"


### PR DESCRIPTION
A new sentence is added to clarify that when a new CID is used, packet number space's largest_ack should be reset to None for the packet number encoding algorithm specified in RFC9000.