### PR TITLE
remove text that contradicts to the WG's effort trying to prevent ossification

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -98,9 +98,6 @@ This proposal is based on several basic design points:
 particular, this proposal uses path validation as specified for QUIC
 version 1 and aims to re-use as much as possible of QUIC's connection
 migration.
-  * Use the same packet header formats as QUIC version 1 to avoid the
-risk of packets being dropped by middleboxes (which may only support
-QUIC version 1)
   * Congestion Control must be per-path (following {{QUIC-TRANSPORT}})
 which usually also requires per-path RTT measurements
   * PMTU discovery should be performed per-path

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -95,7 +95,7 @@ connection.
 This proposal is based on several basic design points:
 
   * Re-use as much as possible mechanisms of QUIC version 1. In
-particular, this proposal uses path validation as specified for QUIC
+particular, this proposal uses packet headers and path validation as specified for QUIC
 version 1 and aims to re-use as much as possible of QUIC's connection
 migration.
   * Congestion Control must be per-path (following {{QUIC-TRANSPORT}})

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -95,9 +95,12 @@ connection.
 This proposal is based on several basic design points:
 
   * Re-use as much as possible mechanisms of QUIC version 1. In
-particular, this proposal uses packet headers and path validation as specified for QUIC
+particular, this proposal uses path validation as specified for QUIC
 version 1 and aims to re-use as much as possible of QUIC's connection
 migration.
+  * Use the same packet header formats as QUIC version 1 to minimize
+    the difference between multipath and non-multipath traffic being
+    exposed on wire.
   * Congestion Control must be per-path (following {{QUIC-TRANSPORT}})
 which usually also requires per-path RTT measurements
   * PMTU discovery should be performed per-path


### PR DESCRIPTION
As a working group, we are spending efforts to prevent ossification (see QUIC v2 draft as an example).

I think it'd be inappropriate to have a statement that sounds as if we think that ossification is inevitable and that QUIC versions other than v1 is going to have lower penetration rate.