### PR TITLE
Proposed text for RTT computation and ACK_MP scheduling

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -915,7 +915,7 @@ the new values. There is however an exception: some congestion
 control functions rely on estimates of the minimum RTT. It might be prudent
 for nodes to remember the path over which the ACK MP that produced
 the minimum RTT was received, and to restart the minimum RTT computation
-if that path is abandoned. 
+if that path is abandoned.
 
 ## Packet Scheduling
 
@@ -938,7 +938,7 @@ the standard algorithm reflect both the characteristics of the
 path and the scheduling algorithm of ACK_MP frames. The estimates will converge
 faster if the scheduling strategy is stable, but besides that
 implementations can choose between multiple strategies such as sending
-ACK_MP frames on the path they acknowledge packets, or sending 
+ACK_MP frames on the path they acknowledge packets, or sending
 ACK_MP frames on the shortest path, which results in shorter control loops
 and thus better performance.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -907,7 +907,7 @@ for example the PTO timeout: if an ACK_MP is not received after more
 than 350ms, either the data packet or its ACK_MP were probably lost.
 
 The simplest implementation is to compute smoothedRTT and RTTvar per
-{{section 5.3 of QUIC-RECOVERY}} regardless of the path through which MP_ACKs are
+{{Section 5.3 of QUIC-RECOVERY}} regardless of the path through which MP_ACKs are
 received. This algorithm will provide good results,
 except if the set of paths changes and the ACK_MP sender
 revisits its sending preferences. This is not very

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -906,12 +906,15 @@ the satellite channel, but it is still the right value for computing
 for example the PTO timeout: if an ACK_MP is not received after more
 than 350ms, either the data packet or its ACK_MP were probably lost.
 
-In general, using the algorithm above will provide good results,
-except if the set of path changes and the ACK_MP sender
+The simplest implementation is to compute smoothedRTT and RTTvar per
+{{section 5.3 of QUIC-RECOVERY}} regardless of the path through which MP_ACKs are
+received. This algorithm will provide good results,
+except if the set of paths changes and the ACK_MP sender
 revisits its sending preferences. This is not very
-different from what happens on a single path if the routing changes,
-and the RTT, RTT variance and PTO estimates will rapidly converge to
-the new values. There is however an exception: some congestion
+different from what happens on a single path if the routing changes.
+The RTT, RTT variance and PTO estimates will rapidly converge to
+reflect the new conditions.
+There is however an exception: some congestion
 control functions rely on estimates of the minimum RTT. It might be prudent
 for nodes to remember the path over which the ACK MP that produced
 the minimum RTT was received, and to restart the minimum RTT computation

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -893,8 +893,8 @@ The ACK_MP frames describe packets that were sent on the specified path,
 but they may be received through any available path. There is an
 understandable concern that if successive acknowledgements are received
 on different paths, the measured RTT samples will fluctuate widely,
-and that might result in poor performance. In fact, this concern is
-probably not justified.
+and that might result in poor performance. While this may be a concern,
+the actual behavior is complex.
 
 The computed values reflect both the state of the network path and the
 scheduling decisions by the sender of the ACK_MP frames. In the example


### PR DESCRIPTION
fixes #132 

This proposed text updates the discussion of RTT computation and ACK_MP scheduling in the Example section, which is not normative. The proposed text reflects the discussion during the working group meeting in Yokohama, and aligns with the apparent consensus that emerged during the discussion.