### PR TITLE
Don't use all CIDs unless rebinding is a nonconcern

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -260,9 +260,11 @@ preferred_address transport parameter" ({{Section 18.2. of QUIC-TRANSPORT}}).
 
 The transport parameter "active_connection_id_limit"
 {{QUIC-TRANSPORT}} limits the number of usable Connection IDs, and also
-limits the number of concurrent paths. For the QUIC multipath extension
-this limit even applies when no connection ID is exposed in the QUIC
-header.
+limits the number of concurrent paths. However, unless NAT rebinding
+({{Section 7.8. of QUIC-TRANSPORT}}) is a nonconcern, endpoints SHOULD
+refrain from using all available Connection IDs to actively open
+additional paths. This is because spare Connection IDs are need to
+respond to unintentional migration events.
 
 
 # Path Setup and Removal {#setup}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -263,7 +263,7 @@ The transport parameter "active_connection_id_limit"
 limits the number of concurrent paths. However, unless NAT rebinding
 ({{Section 7.8. of QUIC-TRANSPORT}}) is a nonconcern, endpoints SHOULD
 refrain from using all available Connection IDs to actively open
-additional paths. This is because spare Connection IDs are need to
+additional paths. This is because spare Connection IDs are needed to
 respond to unintentional migration events.
 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -260,11 +260,9 @@ preferred_address transport parameter" ({{Section 18.2. of QUIC-TRANSPORT}}).
 
 The transport parameter "active_connection_id_limit"
 {{QUIC-TRANSPORT}} limits the number of usable Connection IDs, and also
-limits the number of concurrent paths. However, unless NAT rebinding
-({{Section 7.8. of QUIC-TRANSPORT}}) is a nonconcern, endpoints SHOULD
-refrain from using all available Connection IDs to actively open
-additional paths. This is because spare Connection IDs are needed to
-respond to unintentional migration events.
+limits the number of concurrent paths. However, endpoints might prefer to retain
+spare Connection IDs so that they can respond to unintentional migration events
+({{Section 9.5 of QUIC-TRANSPORT}}).
 
 
 # Path Setup and Removal {#setup}


### PR DESCRIPTION
Closes #221. As discussed in the issue, endpoints need to retain unused CIDs, otherwise they cannot respond to NAT rebinding.

Also removes a stale statement about zero-length CID.