### PR TITLE
clarify the effect on transport machinery at PATH_ABANDON + 3PTO

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -372,11 +372,11 @@ Both endpoints, namely the client and the server, can initiate path closure,
 by sending a PATH_ABANDON frame (see {{path-abandon-frame}}) which
 requests the peer to stop sending packets with the corresponding Destination Connection ID.
 
-The sender and receiver of a PATH_ABANDON frame should not release its resources
-immediately, but SHOULD wait for at least three times the current
-Probe Timeout (PTO) interval as defined in {{Section 6.2. of QUIC-RECOVERY}}
-after the last sent packet before sending the RETIRE_CONNECTION_ID frame
-for the corresponding CID.
+When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
+least three times the current Probe Timeout (PTO) interval as defined in
+{{Section 6.2 of QUIC-RECOVERY}} after the last packet was sent on the path,
+before sending the RETIRE_CONNECTION_ID frame for the corresponding Connection
+ID or ceasing to recognize late acknowledgements.
 This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -376,8 +376,7 @@ When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
 least three times the current Probe Timeout (PTO) interval as defined in
 {{Section 6.2 of QUIC-RECOVERY}} after the last packet was sent on the path,
 before sending the RETIRE_CONNECTION_ID frame for the corresponding Connection
-ID.
-This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
+ID. This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.
 The effect of receiving a RETIRE_CONNECTION_ID frame is specified in the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -376,7 +376,7 @@ When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
 least three times the current Probe Timeout (PTO) interval as defined in
 {{Section 6.2 of QUIC-RECOVERY}} after the last packet was sent on the path,
 before sending the RETIRE_CONNECTION_ID frame for the corresponding Connection
-ID or ceasing to recognize late acknowledgements.
+ID.
 This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.


### PR DESCRIPTION
Closes #232.

The only state that can be discarded at PATH_ABONDON + 3PTO is that used for sending packets, as the states for receiving and acknowledging packets arriving on the abandoned path are expected to be retained until the receipt of RETIRE_CONNECTION_ID.

This PR clarifies that from the viewpoint of state machinery.