### PR TITLE
[+] Explicit path identifier first shot

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -191,7 +191,7 @@ In addition, we define the following term:
   a path in a QUIC connection at an endpoint. Path Identifier is used 
   in multipath control frames (etc. PATH_ABANDON frame) to identify a path. 
   Connection IDs are issued per path ID. When endpoints address a path in 
-  multipath control frames, it refers to the Path Identifier field of 
+  multipath control frames, it refers to the Path Identifier related to
   the destination Connection ID used for sending packets on that 
   particular path. 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -130,7 +130,7 @@ requires negotiation between the two endpoints using a new transport
 parameter, as specified in {{nego}}.
 
 This extension uses multiple packet number spaces.
-When multipath is negotiated, each path is linked to a separate packet number space.
+When multipath is negotiated, each path ID is linked to a separate packet number space.
 Using multiple packet number spaces enables direct use of the
 loss recovery and congestion control mechanisms defined in
 {{QUIC-RECOVERY}}.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -241,7 +241,7 @@ the use of the multipath extension during the connection handshake,
 as specified in {{QUIC-TRANSPORT}}. The new transport parameter is
 defined as follows:
 
-- enable_multipath (current version uses 0x0f739bbc1b666d06): the
+- enable_multipath (current version uses 0x0f739bbc1b666d07): the
   enable_multipath transport parameter is included if the endpoint supports
   the multipath extension as defined in this document. This parameter has
   a zero-length value.
@@ -1371,7 +1371,7 @@ the "QUIC Transport Parameters" registry under the "QUIC Protocol" heading.
 
 Value                                         | Parameter Name.   | Specification
 ----------------------------------------------|-------------------|-----------------
-TBD (current version uses 0x0f739bbc1b666d06) | enable_multipath  | {{nego}}
+TBD (current version uses 0x0f739bbc1b666d07) | enable_multipath  | {{nego}}
 {: #transport-parameters title="Addition to QUIC Transport Parameters Entries"}
 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -931,7 +931,7 @@ between packet number spaces and paths is fixed. A node may
 decide to rotate the Destination CID it uses, a NAT may decide
 to change the 4-tuple over which packets from that path will be
 received. The packet number space does not change when CID
-rotation happens.
+rotation happens within a given Path ID.
 
 Data associated with the transmission and reception on a given
 path can be associated to either the "path state", or to the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1461,15 +1461,8 @@ Loss or reordering can cause an endpoint to receive a MAX_PATHS frame with
 a lower path limit than was previously received. MAX_PATHS frames that 
 do not increase the path limit MUST be ignored.
 
-An endpoint MUST NOT open more paths than permitted by the current path limit 
-set by its peer. For instance, a server that receives a path limit of 3 
-is permitted to open paths 0, 1, 2, but not path 3. An endpoint MUST terminate 
-a connection with an error of type MP_PROTOCOL_VIOLATION if a peer opens 
-more paths than was permitted. 
-
-Note that these frames do not describe the number of paths that can be opened 
-concurrently. The limit includes paths that have been abandoned as well as those 
-that are open.
+An endpoint MUST NOT initiate a path with a path ID higher than the Maximum Paths value.
+An endpoint MUST terminate the a connection with an error of type MP_PROTOCOL_VIOLATION if a peer opens more paths than was permitted. 
 
 
 # Error Codes {#error-codes}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -214,14 +214,15 @@ per path. A multipath QUIC connection is thus an established QUIC
 connection where the enable_multipath transport parameter
 has been successfully negotiated.
 
+Endpoints need to pre-allocate new Connection IDs with associating Path Identifiers 
+before initiating new paths.
 To add a new path to an existing multipath QUIC connection, a client starts a path validation on
 the chosen path, as further described in {{setup}}.
 In this version of the document, a QUIC server does not initiate the creation
 of a path, but it can validate a new path created by a client.
 A new path can only be used once the associated 4-tuple has been validated
 by ensuring that the peer is able to receive packets at that address
-(see {{Section 8 of QUIC-TRANSPORT}}). Endpoints need to pre-allocate 
-new Connection IDs with associating Path Identifiers before initiating new paths.
+(see {{Section 8 of QUIC-TRANSPORT}}). 
 The Path Identifier communicated when advertising a
 Destination Connection ID is used to associate a packet to a packet number space 
 that is used on a valid path. Further, the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -341,8 +341,8 @@ Furthermore, this document
 does not discuss when a client decides to initiate a new path. We
 delegate such discussion in separate documents.
 
-To open a new path, endpoint needs to provide its peer with alternative connection IDs
-which are pre-allocated with Path Identifiers. 
+To open a new path, an endpoint needs to provide its peer with connection IDs
+for a new path (as identified by the Path Identifier). 
 
 To open a new path, an endpoint SHALL use different Connection IDs on different paths.
 Still, the receiver may observe the same Connection ID used on different

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -130,7 +130,7 @@ requires negotiation between the two endpoints using a new transport
 parameter, as specified in {{nego}}.
 
 This extension uses multiple packet number spaces.
-When multipath is negotiated, each path ID is linked to a separate packet number space.
+When multipath is negotiated, each separate packet number space is linked to a path ID. 
 Using multiple packet number spaces enables direct use of the
 loss recovery and congestion control mechanisms defined in
 {{QUIC-RECOVERY}}.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -369,7 +369,7 @@ use of a new Connection ID (see {{Section 9.5 of QUIC-TRANSPORT}}).
 Following {{QUIC-TRANSPORT}}, each endpoint uses MP_NEW_CONNECTION_ID frames
 to issue usable connections IDs to reach it. As such to open
 a new path by initiating path validation, both sides need at least
-one unused Connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}).
+one Connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated with an unused Path ID. 
 
 If the transport parameter "initial_max_paths" is negotiated as N, 
 and the client is already actively using N paths, the limit is reached. 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1300,9 +1300,9 @@ MP_NEW_CONNECTION_ID frames are formatted as shown in {{fig-mp-connection-id-fra
 ~~~
 MP_NEW_CONNECTION_ID Frame {
   Type (i) = 0x15228c09,
-  Path Identifier (i),
   Sequence Number (i),
   Retire Prior To (i),
+  Path Identifier (i),
   Length (8),
   Connection ID (8..160),
   Stateless Reset Token (128),

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -257,7 +257,7 @@ defined as follows:
   be at least 2. An endpoint that receives a value less than 2 MUST close 
   the connection with an error of type TRANSPORT_PARAMETER_ERROR. After the handshake 
   negotiation finished, endpoints MUST use the minimum of local and remote
-  value of max_concurrent_paths as the maximum number of paths in the current
+  value of max_concurrent_paths as the maximum number of concurrent paths in the current
   connection. 
 
 If any of the endpoints does not advertise the enable_multipath transport
@@ -289,8 +289,8 @@ enable_multipath parameter is negotiated. Endpoints SHOULD use
 MP_NEW_CONNECTION_ID and MP_RETIRE_CONNECTION_ID frames to provide new Connection IDs 
 for the peer after the enable_multipath parameter is negotiated. 
 
-Path Identifier allocated by endpoints MUST NOT be larger or equal to 
-the max_concurrent_paths transport parameter which is negotiated by endpoints.
+Endpoints MUST NOT allocate more active Path Identifiers than 
+the max_concurrent_paths transport parameter negotiated by endpoints.
 
 Cipher suites with nonce shorter than 12 bytes cannot be used together with
 the multipath extension. If such cipher suite is selected and the use of the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1266,7 +1266,10 @@ before or during path initiation.
 
 ## MP_NEW_CONNECTION_ID frames {#mp-new-conn-id-frame}
 
-An endpoint sends a MP_NEW_CONNECTION_ID frame (type=0x15228c09) instead of the NEW_CONNECTION_ID frame to provide its peer with alternative connection IDs that can be used to break linkability when migrating connections; see {{Section 19.15 of QUIC-TRANSPORT}}.
+An endpoint sends a MP_NEW_CONNECTION_ID frame (type=0x15228c09) instead of 
+the NEW_CONNECTION_ID frame to provide its peer with alternative connection IDs 
+that can be used to break linkability when migrating connections; 
+see {{Section 19.15 of QUIC-TRANSPORT}}.
 
 MP_NEW_CONNECTION_ID frames are formatted as shown in {{fig-mp-connection-id-frame-format}}.
 
@@ -1293,7 +1296,12 @@ means the current Connection ID can only be used on the corresponding path.
 
 ## MP_RETIRE_CONNECTION_ID frames {#mp-retire-conn-id-frame}
 
-An endpoint sends a MP_RETIRE_CONNECTION_ID frame (type=0x15228c0a) instead of RETIRE_CONNECTION_ID frame to indicate that it will no longer use a connection ID that was issued by its peer. This includes the connection ID provided during the handshake. Sending a MP_RETIRE_CONNECTION_ID frame also serves as a request to the peer to send additional connection IDs for future use. New connection IDs can be delivered to a peer using the MP_NEW_CONNECTION_ID frame ({{mp-new-conn-id-frame}}).
+An endpoint sends a MP_RETIRE_CONNECTION_ID frame (type=0x15228c0a) instead of 
+RETIRE_CONNECTION_ID frame to indicate that it will no longer use a connection ID 
+that was issued by its peer. This includes the connection ID provided during the handshake. 
+Sending a MP_RETIRE_CONNECTION_ID frame also serves as a request to the peer 
+to send additional connection IDs for future use. New connection IDs can be 
+delivered to a peer using the MP_NEW_CONNECTION_ID frame ({{mp-new-conn-id-frame}}).
 
 Retiring a connection ID invalidates the stateless reset token associated with that connection ID.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -236,6 +236,15 @@ defined as follows:
   enable_multipath transport parameter is included if the endpoint supports
   the multipath extension as defined in this document. This parameter has
   a zero-length value.
+- max_concurrent_paths (current version uses 0x0f739bbc1b666df1): This is 
+  an integer value specifying the maximum number of paths an endpoint is 
+  willing to build. The value of the max_concurrent_paths parameter MUST 
+  be at least 2. An endpoint that receives a value less than 2 MUST close 
+  the connection with an error of type TRANSPORT_PARAMETER_ERROR. If this 
+  transport parameter is absent, a default of 4 is assumed. After the handshake 
+  negotiation finished, endpoints MUST use the minimum of local and remote
+  value of max_concurrent_paths as the maximum number of paths in the current
+  connection.
 
 If any of the endpoints does not advertise the enable_multipath transport
 parameter, then the endpoints MUST NOT use any frame or

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -251,7 +251,7 @@ defined as follows:
   a zero-length value.
 
 - max_concurrent_paths (current version uses 0xced74c7a): This is 
-  a variable-length integer value specifying the maximum number of paths an endpoint is 
+  a variable-length integer value specifying the maximum number of active concurrent paths an endpoint is 
   willing to build. The value of the max_concurrent_paths parameter MUST 
   be at least 2. An endpoint that receives a value less than 2 MUST close 
   the connection with an error of type TRANSPORT_PARAMETER_ERROR. If this 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -190,7 +190,7 @@ In addition, we define the following term:
 - Path Identifier (Path ID): An identifier that is used to identify 
   a path in a QUIC connection at an endpoint. Path Identifier is used 
   in multipath control frames (etc. PATH_ABANDON frame) to identify a path. 
-  Connection IDs are issued per path. When endpoints address a path in 
+  Connection IDs are issued per path ID. When endpoints address a path in 
   multipath control frames, it refers to the Path Identifier field of 
   the destination Connection ID used for sending packets on that 
   particular path. 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -247,7 +247,7 @@ defined as follows:
   a zero-length value.
 
 - max_concurrent_paths (current version uses 0xced74c7a): This is 
-  an integer value specifying the maximum number of paths an endpoint is 
+  a variable-length integer value specifying the maximum number of paths an endpoint is 
   willing to build. The value of the max_concurrent_paths parameter MUST 
   be at least 2. An endpoint that receives a value less than 2 MUST close 
   the connection with an error of type TRANSPORT_PARAMETER_ERROR. If this 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -321,6 +321,10 @@ which are issued by origin NEW_CONNECTION_ID frames {{Section 19.15. of QUIC-TRA
 MUST be treated as their Path Identifier is 0. Also, the Path Identifier for 
 the connection ID specified in the "preferred address" transport parameter is 1.
 
+Endpoints use PATH_ABANDON frame to inform the peer of the retirement of associated 
+Path Identifier. When there is not enough unused Path Identifiers, endpoints SHOULD
+send MAX_PATHS frame to inform the peer that new Path Identifiers are available.
+
 
 # Path Setup and Removal {#setup}
 
@@ -514,12 +518,21 @@ the server MAY wait for a short, limited time such as one PTO if a path
 probing packet is received on a new path before sending the
 CONNECTION_CLOSE frame.
 
+Note that PATH_ABANDON frame is also used as a signal for the retirement 
+of the associated Path Identifier. When endpoint received PATH_ABANDON frame,
+it SHOULD not use the associated Path Identifier in future packets, it can 
+only use the Path ID in ACK_MP frames for inflight packets or 
+in MP_RETIRE_CONNECTION_ID frames for CID retirement.
+
 ### Refusing a New Path
 
 An endpoint may deny the establishment of a new path initiated by its
 peer during the address validation procedure. According to
 {{QUIC-TRANSPORT}}, the standard way to deny the establishment of a path
 is to not send a PATH_RESPONSE in response to the peer's PATH_CHALLENGE.
+
+If endpoint fails to validate a path and consume an available Path Identifier,
+it SHOULD send a PATH_ABANDON frame to retire the associated Path Identifier. 
 
 
 ### Allocating, Consuming and Retiring Connection IDs {#consume-retire-cid}
@@ -1174,7 +1187,7 @@ Path Identifier:
 
 ## PATH_ABANDON Frame {#path-abandon-frame}
 
-The PATH_ABANDON frame informs the peer to abandon a path.
+The PATH_ABANDON frame informs the peer to abandon a path and retire the Path ID associated.
 
 PATH_ABANDON frames are formatted as shown in {{fig-path-abandon-format}}.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -720,7 +720,7 @@ peer in this new CID's packet number space is initially set to "None".
 The ACK_MP frame, as specified in {{ack-mp-frame}}, is used to
 acknowledge 1-RTT packets.
 Compared to the QUIC version 1 ACK frame, the ACK_MP frame additionally
-contains the receiver's Path Identifier field pre-allocated in Destination Connection ID
+contains the receiver's Path Identifier associated with the Destination Connection ID
 to distinguish the path-specific packet number space.
 
 Acknowledgements of Initial and Handshake packets MUST be carried using

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1378,7 +1378,8 @@ An endpoint sends a MP_RETIRE_CONNECTION_ID frame (type=0x15228c0a) instead of
 RETIRE_CONNECTION_ID frame to indicate that it will no longer use a connection ID 
 that was issued by its peer. This includes the connection ID provided during the handshake. 
 Sending a MP_RETIRE_CONNECTION_ID frame also serves as a request to the peer 
-to send additional connection IDs for future use. New connection IDs can be 
+to send additional connection IDs for future use, unless the path specified 
+by Path Identifier has been abandoned. New connection IDs can be 
 delivered to a peer using the MP_NEW_CONNECTION_ID frame ({{mp-new-conn-id-frame}}).
 
 Retiring a connection ID invalidates the stateless reset token associated with that connection ID.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -352,7 +352,8 @@ and associated Path Identifiers for the new path.
 To open a new path, an endpoint SHALL use different Connection IDs on different paths.
 Still, the receiver may observe the same Connection ID used on different
 4-tuples due to, e.g., NAT rebinding. In such case, the receiver reacts
-as specified in {{Section 9.3 of QUIC-TRANSPORT}}.
+as specified in {{Section 9.3 of QUIC-TRANSPORT}} by initiating path validation
+and using a new Connection ID for the same path ID.
 
 This proposal adds three multipath control frames for path management:
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -816,9 +816,9 @@ using multiple packet number spaces.
    Client                                                  Server
 
    (Exchanges start on default path)
-   1-RTT[]: NEW_CONNECTION_ID[C1, Seq=1, PathID=1] -->
-             <-- 1-RTT[]: NEW_CONNECTION_ID[S1, Seq=1, PathID=1]
-             <-- 1-RTT[]: NEW_CONNECTION_ID[S2, Seq=2, PathID=2]
+   1-RTT[]: MP_NEW_CONNECTION_ID[C1, Seq=0, PathID=1] -->
+             <-- 1-RTT[]: MP_NEW_CONNECTION_ID[S1, Seq=0, PathID=1]
+             <-- 1-RTT[]: MP_NEW_CONNECTION_ID[S2, Seq=0, PathID=2]
    ...
    (starts new path)
    1-RTT[0]: DCID=S2, PATH_CHALLENGE[X] -->

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -191,8 +191,7 @@ In addition, we define the following terms:
 - Path Identifier (Path ID): An identifier that is used to identify 
   a path in a QUIC connection at an endpoint. Path Identifier is used 
   in multipath control frames (etc. PATH_ABANDON frame) to identify a path. 
-  Endpoint pre-allocates a Path Identifier field when it provide a new Connection ID
-  for its peer. When endpoints address a path in multipath control frames, 
+  Connection IDs are issued per path. When endpoints address a path in multipath control frames, 
   it refers to the Path Identifier field of the destination Connection ID 
   used for sending packets on that particular path. 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -521,8 +521,33 @@ peer during the address validation procedure. According to
 is to not send a PATH_RESPONSE in response to the peer's PATH_CHALLENGE.
 
 
-### Consuming and Retiring Connection IDs {#consume-retire-cid}
+### Allocating, Consuming and Retiring Connection IDs {#consume-retire-cid}
 
+Each endpoints pre-allocate a Path Identifier for each new Connection ID. 
+The Path Identifier 0 indicates the initial path of the connection. 
+Endpoints SHOULD issue at least one unused Connection ID for each path.
+
+An endpoint maintains a set of connection IDs received from its peer for each path, 
+any of which it can use when sending packets, as the same in {{QUIC-TRANSPORT}}. 
+The difference of multi-path extension is that Connection IDs are pre-allocated
+for each paths. Each Connection ID is belonging to one path specified by
+the Path Identifier field of MP_NEW_CONNECTION_ID frame in {{mp-new-conn-id-frame}}.
+The Connection IDs used during handshake are belonging to the initial path
+with Path Identifier 0.
+
+When the endpoint wishes to remove a connection ID from use, it sends 
+a MP_RETIRE_CONNECTION_ID frame {{mp-retire-conn-id-frame}} to its peer. 
+Sending a MP_RETIRE_CONNECTION_ID frame indicates that the connection ID 
+will not be used again and requests that the peer replace it with a new connection ID 
+using a MP_NEW_CONNECTION_ID frame.
+
+Note that Connection Sequeunce number and Retire Prior To field are both used for 
+the corresponding path specified by a Path Identifier. 
+
+Upon receipt of an increased Retire Prior To field, the peer MUST stop 
+using the corresponding connection IDs of the specified path and retire them 
+with MP_RETIRE_CONNECTION_ID frames before adding the newly provided connection ID 
+to the set of active connection IDs belonging to the specified path.
 
 
 ### Effect of RETIRE_CONNECTION_ID Frame {#retire-cid-close}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -520,6 +520,11 @@ peer during the address validation procedure. According to
 {{QUIC-TRANSPORT}}, the standard way to deny the establishment of a path
 is to not send a PATH_RESPONSE in response to the peer's PATH_CHALLENGE.
 
+
+### Consuming and Retiring Connection IDs {#consume-retire-cid}
+
+
+
 ### Effect of RETIRE_CONNECTION_ID Frame {#retire-cid-close}
 
 Receiving a RETIRE_CONNECTION_ID frame causes an endpoint to discard
@@ -1317,6 +1322,46 @@ Path Identifier:
 : A path identifier which is pre allocated when the Connection ID is generated, which
 means the current Connection ID can only be used on the corresponding path.
 
+Sequence Number:
+The sequence number assigned to the connection ID by the sender on the path 
+specified by Path Identifier, encoded as a variable-length integer. 
+Note that the sequence number is allocated dependently on each path, 
+which means different Connection IDs on different paths may have the same 
+sequence number value.
+
+Retire Prior To:
+: A variable-length integer indicating which connection IDs should be retired 
+on the path specified by Path Identifier; see {{consume-retire-cid}}.
+
+Length:
+An 8-bit unsigned integer containing the length of the connection ID. Values 
+less than 1 and greater than 20 are invalid and MUST be treated as a connection 
+error of type FRAME_ENCODING_ERROR.
+
+Connection ID:
+A connection ID of the specified length.
+
+Stateless Reset Token:
+A 128-bit value that will be used for a stateless reset when the associated 
+connection ID is used.
+
+The Sequence Number field and Retire Prior To field is allocated 
+for each path independently.
+
+The Retire Prior To field applies to connection IDs established during 
+connection setup if the Path Identifier is 0 indicating the initial path; see {{consume-retire-cid}}. 
+The value in the Retire Prior To field MUST be less than or equal to the value 
+in the Sequence Number field. Receiving a value in the Retire Prior To field 
+that is greater than that in the Sequence Number field MUST be treated as 
+a connection error of type FRAME_ENCODING_ERROR.
+
+Length, Connection ID, Stateless Reset Token fields have exactly the same
+definition in NEW_CONNECTION_ID frame {{Section 19.15 of QUIC-TRANSPORT}}.
+
+Note that Connection IDs issued in NEW_CONNECTION_ID frames MUST be treated as
+their Path Identifier is 0. Also the retire prior to field of NEW_CONNECTION_ID frames
+just effect the Connection IDs of initial path with path ID 0. This machanism 
+is compatible with {{QUIC-Transport}}.
 
 
 ## MP_RETIRE_CONNECTION_ID frames {#mp-retire-conn-id-frame}
@@ -1333,7 +1378,7 @@ Retiring a connection ID invalidates the stateless reset token associated with t
 MP_RETIRE_CONNECTION_ID frames are formatted as shown in {{fig-mp-retire-connection-id-frame-format}}.
 
 ~~~
-RETIRE_CONNECTION_ID Frame {
+MP_RETIRE_CONNECTION_ID Frame {
   Type (i) = 0x15228c0a,
   Path Identifier (i),
   Sequence Number (i),
@@ -1344,6 +1389,10 @@ RETIRE_CONNECTION_ID Frame {
 Path Identifier:
 : A path identifier which is pre allocated when the Connection ID is generated, which
 means the current Connection ID can only be used on the corresponding path.
+
+Sequence Number:
+The sequence number assigned to the connection ID by the sender on the path 
+specified by Path Identifier, encoded as a variable-length integer. 
 
 
 # Error Codes {#error-codes}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1289,7 +1289,7 @@ PATH_AVAILABLE frames are formatted as shown in {{fig-path-available-format}}.
 ~~~
   PATH_AVAILABLE Frame {
     Type (i) = TBD-03 (experiments use 0x15228c08),
-    Destination Connection ID Sequence Number (i),
+    Path Identifier (i),
     Path Status sequence number (i),
   }
 ~~~

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1300,9 +1300,9 @@ MP_NEW_CONNECTION_ID frames are formatted as shown in {{fig-mp-connection-id-fra
 ~~~
 MP_NEW_CONNECTION_ID Frame {
   Type (i) = 0x15228c09,
+  Path Identifier (i),
   Sequence Number (i),
   Retire Prior To (i),
-  Path Identifier (i),
   Length (8),
   Connection ID (8..160),
   Stateless Reset Token (128),
@@ -1334,8 +1334,8 @@ MP_RETIRE_CONNECTION_ID frames are formatted as shown in {{fig-mp-retire-connect
 ~~~
 RETIRE_CONNECTION_ID Frame {
   Type (i) = 0x15228c0a,
-  Sequence Number (i),
   Path Identifier (i),
+  Sequence Number (i),
 }
 ~~~
 {: #fig-mp-retire-connection-id-frame-format title="MP_RETIRE_CONNECTION_ID Frame Format"}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -926,8 +926,9 @@ from the list of CID provided by the peer. Packets received
 on the path carry a Destination CID selected by the peer from
 the list provided to that peer.
 
-The relation between CIDs and paths is not fixed, but the relation
-between packet number spaces and paths is fixed. A node may
+The relation between packet number spaces and paths is fixed. 
+CIDs are pre-allocated for each Path Identifier. Once CIDs are issued, 
+they are assigned to one specific Path Identifier. A node may
 decide to rotate the Destination CID it uses, a NAT may decide
 to change the 4-tuple over which packets from that path will be
 received. The packet number space does not change when CID

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -320,7 +320,7 @@ construct the packet protection nonce defined in {#multipath-aead}.
 The Path Identifier associated with the Destination Connection ID 
 is used to identify the path in ACK_MP frames {#ack-mp-frame}.
 
-Note that the Path Identifier for initial path is always 0. Connection IDs
+Note that the Path Identifier for the initial path is 0. Connection IDs
 which are issued by origin NEW_CONNECTION_ID frames {{Section 19.15. of QUIC-TRANSPORT}}
 MUST be treated as their Path Identifier is 0.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -322,7 +322,8 @@ is used to identify the path in ACK_MP frames {#ack-mp-frame}.
 
 Note that the Path Identifier for the initial path is 0. Connection IDs
 which are issued by origin NEW_CONNECTION_ID frames {{Section 19.15. of QUIC-TRANSPORT}}
-MUST be treated as their Path Identifier is 0.
+MUST be treated as their Path Identifier is 0. Also, the Path Identifier for 
+the connection ID specified in the "preferred address" transport parameter is 1.
 
 
 # Path Setup and Removal {#setup}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -530,7 +530,7 @@ is to not send a PATH_RESPONSE in response to the peer's PATH_CHALLENGE.
 
 Each endpoints pre-allocate a Path Identifier for each new Connection ID. 
 The Path Identifier 0 indicates the initial path of the connection. 
-Endpoints SHOULD issue at least one unused Connection ID for each path.
+Endpoints SHOULD issue at least one unused Connection ID with unused Path Identifier.
 
 An endpoint maintains a set of connection IDs received from its peer for each path, 
 any of which it can use when sending packets, as the same in {{QUIC-TRANSPORT}}. 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -208,7 +208,9 @@ See further {{nego}}.
 The peers use the enable_multipath transport parameter during the handshake to
 negotiate the utilization of the multipath capabilities.
 The max_concurrent_paths transport parameter limits the maximum number of active paths
-that can be used during a connection. A multipath QUIC connection is thus an established QUIC
+that can be used during a connection. The active_connection_id_limit 
+transport parameter limits the maximum number of active Connection IDs
+per path. A multipath QUIC connection is thus an established QUIC
 connection where the enable_multipath transport parameter
 has been successfully negotiated.
 
@@ -277,14 +279,13 @@ This extension does not change the definition of any transport parameter
 defined in {{Section 18.2. of QUIC-TRANSPORT}}.
 
 The transport parameter "active_connection_id_limit"
-{{QUIC-TRANSPORT}} limits the number of usable Connection IDs, and also
-limits the number of concurrent paths. Note that max_concurrent_paths SHOULD not 
-be larger than active_connection_id_limit. However, endpoints might prefer to retain
-spare Connection IDs so that they can respond to unintentional migration events
-({{Section 9.5 of QUIC-TRANSPORT}}). 
+{{QUIC-TRANSPORT}} limits the number of usable Connection IDs per path when the
+enable_multipath parameter is negotiated successfully. 
+Endpoints might prefer to retain spare Connection IDs so that they can 
+respond to unintentional migration events ({{Section 9.5 of QUIC-TRANSPORT}}). 
 
-The transport parameter "max_concurrent_paths" only becomes effective when the
-enable_multipath parameter is negotiated successfully. Endpoints SHOULD use
+The transport parameter "max_concurrent_paths" only becomes effective after the
+enable_multipath parameter is negotiated. Endpoints SHOULD use
 MP_NEW_CONNECTION_ID and MP_RETIRE_CONNECTION_ID frames to provide new Connection IDs 
 for the peer after the enable_multipath parameter is negotiated. 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -945,7 +945,7 @@ state of either the sender or receiver number spaces. For example:
   packets sent and not yet acknowledged. Such information, along
   with the value of the next PN to use for sending, is
   logically associated with the "Sender Number Space", which remain
-  unchanged when CID rotation happens
+  unchanged when CID rotation happens.
 
 * Sending of acknowledgement requires keeping track of the PN of
   received packets and of acknowledgements previously sent. Such

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -893,6 +893,16 @@ Client                                                      Server
 ~~~
 {: #fig-example-path-close1 title="Example of closing a path."}
 
+After a path is abandoned, the Path Identifier associated with the path
+is considered retired and MUST NOT be reused in new paths for security 
+consideration {{multipath-aead}}. 
+
+Endpoint SHOULD send MAX_PATHS frames {{max-paths-frame}} to raise 
+the limit of Path Identifiers when endpoint finds there are not enough unused
+Path Identifiers (e.g. more than half of the available Path Identifiers
+are used).
+
+
 # Implementation Considerations
 
 ## Number Spaces
@@ -1490,6 +1500,7 @@ TBD-03 (experiments use 0x15228c07)                  | PATH_STANDBY        | {{p
 TBD-04 (experiments use 0x15228c08)                  | PATH_AVAILABLE      | {{path-available-frame}}
 TBD-05 (experiments use 0x15228c09)                  | MP_NEW_CONNECTION_ID   | {{mp-new-conn-id-frame}}
 TBD-06 (experiments use 0x15228c0a)                  | MP_RETIRE_CONNECTION_ID| {{mp-retire-conn-id-frame}}
+TBD-06 (experiments use 0x15228c0b)                  | MAX_PATHS              | {{max-paths-frame}}
 {: #frame-types title="Addition to QUIC Frame Types Entries"}
 
 The following transport error code defined in {{tab-error-code}} should

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -205,13 +205,13 @@ selects only one path to exchange such frames.
 
 A multipath QUIC connection starts with a QUIC handshake as a regular QUIC connection.
 See further {{nego}}.
-The peers use the enable_multipath transport parameter during the handshake to
+The peers use the initial_max_paths transport parameter during the handshake to
 negotiate the utilization of the multipath capabilities.
 The initial_max_paths transport parameter limits the initial maximum number of active paths
 that can be used during a connection. The active_connection_id_limit 
 transport parameter limits the maximum number of active Connection IDs
 per path. A multipath QUIC connection is thus an established QUIC
-connection where the enable_multipath transport parameter
+connection where the initial_max_paths transport parameter
 has been successfully negotiated.
 
 Endpoints need to pre-allocate new Connection IDs with associating Path Identifiers 
@@ -246,31 +246,29 @@ the use of the multipath extension during the connection handshake,
 as specified in {{QUIC-TRANSPORT}}. The new transport parameter is
 defined as follows:
 
-- enable_multipath (current version uses 0x0f739bbc1b666d07): the
-  enable_multipath transport parameter is included if the endpoint supports
-  the multipath extension as defined in this document. This parameter has
-  a zero-length value.
-
-- initial_max_paths (current version uses 0xced74c7a): This is 
-  a variable-length integer value specifying the maximum number of active concurrent paths an endpoint is 
-  willing to build. The value of the initial_max_paths parameter MUST 
-  be at least 2. An endpoint that receives a value less than 2 MUST close 
+- initial_max_paths (current version uses 0x0f739bbc1b666d07): the
+  initial_max_paths transport parameter is included if the endpoint supports
+  the multipath extension as defined in this document. This is 
+  a variable-length integer value specifying the maximum number of 
+  active concurrent paths an endpoint is willing to build. 
+  The value of the initial_max_paths parameter MUST be at least 2. 
+  An endpoint that receives a value less than 2 MUST close 
   the connection with an error of type TRANSPORT_PARAMETER_ERROR. Setting 
   this parameter is equivalent to sending a MAX_PATHS ({{max-paths-frame}}) 
-  of the corresponding type with the same value
+  of the corresponding type with the same value.
 
-If any of the endpoints does not advertise the enable_multipath transport
+If any of the endpoints does not advertise the initial_max_paths transport
 parameter, then the endpoints MUST NOT use any frame or
 mechanism defined in this document.
 
-When advertising the enable_multipath transport parameter, the endpoint
+When advertising the initial_max_paths transport parameter, the endpoint
 MUST use non-zero source and destination connection IDs.
-If an enable_multipath transport
+If an initial_max_paths transport
 parameter is received and the carrying packet contains a zero
 length connection ID, the receiver MUST treat this as a connection error of type
 MP_PROTOCOL_VIOLATION and close the connection.
 
-The enable_multipath parameter MUST NOT be remembered
+The initial_max_paths parameter MUST NOT be remembered
 ({{Section 7.4.1 of QUIC-TRANSPORT}}).
 New paths can only be used after handshake completion.
 
@@ -279,14 +277,12 @@ defined in {{Section 18.2. of QUIC-TRANSPORT}}.
 
 The transport parameter "active_connection_id_limit"
 {{QUIC-TRANSPORT}} limits the number of usable Connection IDs per path when the
-enable_multipath parameter is negotiated successfully. 
+initial_max_paths parameter is negotiated successfully. 
 Endpoints might prefer to retain spare Connection IDs so that they can 
 respond to unintentional migration events ({{Section 9.5 of QUIC-TRANSPORT}}). 
 
-The transport parameter "initial_max_paths" only becomes effective after the
-enable_multipath parameter is negotiated. Endpoints SHOULD use
-MP_NEW_CONNECTION_ID and MP_RETIRE_CONNECTION_ID frames to provide new Connection IDs 
-for the peer after the enable_multipath parameter is negotiated. 
+Endpoints SHOULD use MP_NEW_CONNECTION_ID and MP_RETIRE_CONNECTION_ID 
+frames to provide new Connection IDs for the peer after the initial_max_paths parameter is negotiated. 
 
 Endpoints MUST NOT issue Connection IDs with Path Identifiers larger than 
 the path limitation declared by the initial_max_paths transport parameter 
@@ -1485,7 +1481,7 @@ the "QUIC Transport Parameters" registry under the "QUIC Protocol" heading.
 
 Value                                         | Parameter Name.   | Specification
 ----------------------------------------------|-------------------|-----------------
-TBD (current version uses 0x0f739bbc1b666d07) | enable_multipath  | {{nego}}
+TBD (current version uses 0x0f739bbc1b666d07) | initial_max_paths | {{nego}}
 {: #transport-parameters title="Addition to QUIC Transport Parameters Entries"}
 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -222,7 +222,7 @@ A new path can only be used once the associated 4-tuple has been validated
 by ensuring that the peer is able to receive packets at that address
 (see {{Section 8 of QUIC-TRANSPORT}}). Endpoints need to pre-allocate 
 new Connection IDs with associating Path Identifiers before initiating new paths.
-The Path Identifier of the 
+The Path Identifier communicated when advertising a
 Destination Connection ID is used to associate a packet to a packet number space 
 that is used on a valid path. Further, the
 Path Identifier of Destination Connection ID is used as numerical identifier

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -256,7 +256,7 @@ defined as follows:
   willing to build. The value of the initial_max_paths parameter MUST 
   be at least 2. An endpoint that receives a value less than 2 MUST close 
   the connection with an error of type TRANSPORT_PARAMETER_ERROR. Setting 
-  this parameter is equivalent to sending a MP_MAX_PATHS ({{mp-max-paths-frame}}) 
+  this parameter is equivalent to sending a MAX_PATHS ({{max-paths-frame}}) 
   of the corresponding type with the same value
 
 If any of the endpoints does not advertise the enable_multipath transport
@@ -290,7 +290,7 @@ for the peer after the enable_multipath parameter is negotiated.
 
 Endpoints MUST NOT issue Connection IDs with Path Identifiers larger than 
 the path limitation declared by the initial_max_paths transport parameter 
-and MP_MAX_PATHS frames.
+and MAX_PATHS frames.
 
 Cipher suites with nonce shorter than 12 bytes cannot be used together with
 the multipath extension. If such cipher suite is selected and the use of the
@@ -554,7 +554,7 @@ with MP_RETIRE_CONNECTION_ID frames before adding the newly provided connection 
 to the set of active connection IDs belonging to the specified path.
 
 Endpoints MUST NOT issue new Connection IDs which has Path Identifiers larger than 
-the max path identifier field in MP_MAX_PATHS frames {{mp-max-paths-frame}}. 
+the max path identifier field in MP_MAX_PATHS frames {{max-paths-frame}}. 
 When endpoint finds it has not enough available unused Path Identifiers,
 it SHOULD send a MP_MAX_PATHS frame to inform the peer that it could use larger active
 Path Identifiers.
@@ -1410,22 +1410,22 @@ The sequence number assigned to the connection ID by the sender on the path
 specified by Path Identifier, encoded as a variable-length integer. 
 
 
-## MP_MAX_PATHS frames {#mp-max-paths-frame}
+## MAX_PATHS frames {#max-paths-frame}
 
-A MP_MAX_PATHS frame (type=0x15228c0b) informs the peer of the cumulative number of paths 
+A MAX_PATHS frame (type=0x15228c0b) informs the peer of the cumulative number of paths 
 it is permitted to open. 
 
-MP_MAX_PATHS frames are formatted as shown in {{fig-mp-max-paths-frame-format}}.
+MAX_PATHS frames are formatted as shown in {{fig-max-paths-frame-format}}.
 
 ~~~
-MP_MAX_PATHS Frame {
+MAX_PATHS Frame {
   Type (i) = 0x15228c0b,
-  Maximum Path Identifier (i),
+  Maximum Paths (i),
 }
 ~~~
-{: #fig-mp-max-paths-frame-format title="MP_MAX_PATHS Frame Format"}
+{: #fig-max-paths-frame-format title="MAX_PATHS Frame Format"}
 
-MP_MAX_PATHS frames contain the following field:
+MAX_PATHS frames contain the following field:
 
 Maximum Path Identifier:
 : A count of the cumulative number of path that can be opened 
@@ -1434,8 +1434,8 @@ possible to encode Path IDs larger than 2^32-1. Receipt of a frame that permits
 opening of a path with Path Identifier larger than this limit MUST be treated 
 as a connection error of type FRAME_ENCODING_ERROR.
 
-Loss or reordering can cause an endpoint to receive a MP_MAX_PATHS frame with 
-a lower path limit than was previously received. MP_MAX_PATHS frames that 
+Loss or reordering can cause an endpoint to receive a MAX_PATHS frame with 
+a lower path limit than was previously received. MAX_PATHS frames that 
 do not increase the path limit MUST be ignored.
 
 An endpoint MUST NOT open more paths than permitted by the current path limit 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -439,7 +439,7 @@ If no frame indicating a path usage preference was received for a certain path,
 the preference of the peer is unknown and the sender needs to decide based on it
 own local logic if the path should be used.
 
-Endpoints use Path Identifier pre-allocated for the Destination Connection ID
+Endpoints use Path Identifier
 in these frames to identify which path state is going to be
 changed. Notice that both frames can be sent via a different path
 and therefore might arrive in different orders.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -194,8 +194,7 @@ In addition, we define the following terms:
   Endpoint pre-allocates a Path Identifier field when it provide a new Connection ID
   for its peer. When endpoints address a path in multipath control frames, 
   it refers to the Path Identifier field of the destination Connection ID 
-  used for sending packets on that particular path. Note that the Path Identifier 
-  for initial path is always 0. 
+  used for sending packets on that particular path. 
 
 
 # High-level overview {#overview}
@@ -295,6 +294,32 @@ the multipath extension. If such cipher suite is selected and the use of the
 multipath extension is negotiated, endpoints MUST abort the handshake with a
 TRANSPORT_PARAMETER error.
 
+
+# Path Identifier {#pathid}
+
+The explicit Path Identifier is an integer between 0 and 2^62 - 1. 
+The Path Identifier is pre-allocated when endpoints provide new Connection IDs
+with MP_NEW_CONNECTION_ID frames {{mp-new-conn-id-frame}}.
+
+Each Connection ID is associated with a Path Identifier, as documented in {{mp-new-conn-id-frame}}. 
+Multiple connection identifiers can be associated with the same path identifier.
+
+Endpoints use Path Identifier to address a path in the multi-path control frames,
+such as PATH_ABANDON, PATH_STANDBY, and PATH_AVAILABLE frames.
+
+Each endpoint associates a Receiver Packet Number space to each Path Identifier 
+that it provides to the peer. Each endpoint associates a Sender Packet Number space 
+to each Path Identifier received from the peer.
+
+The Path Identifier associated with the Destination Connection ID is used to 
+construct the packet protection nonce defined in {#multipath-aead}.
+
+The Path Identifier associated with the Destination Connection ID 
+is used to identify the path in ACK_MP frames {#ack-mp-frame}.
+
+Note that the Path Identifier for initial path is always 0. Connection IDs
+which are issued by origin NEW_CONNECTION_ID frames {{Section 19.15. of QUIC-TRANSPORT}}
+MUST be treated as their Path Identifier is 0.
 
 
 # Path Setup and Removal {#setup}
@@ -700,23 +725,23 @@ the packet number alone would not guarantee the uniqueness of the nonce.
 
 In order to guarantee the uniqueness of the nonce, the nonce N is
 calculated by combining the packet protection IV with the packet number
-and with the least significant 32 bits of the Destination Connection ID
-sequence number.
+and with the least significant 32 bits of the path identifier pre-allocated 
+for the Destination Connection ID.
 
-{{Section 19 of QUIC-TRANSPORT}} encodes the Connection ID Sequence
-Number as a variable-length integer,
-allowing values up to 2^62-1; in this specification, a range of less than 2^32-1
+{{mp-new-conn-id-frame}} encodes the Path Identifier for Connection IDs 
+as a variable-length integer, allowing values up to 2^62-1; 
+in this specification, a range of less than 2^32-1
 values MUST be used before updating the packet protection key.
 
 To calculate the nonce, a 96 bit path-and-packet-number is composed of the least
-significant 32 bits of the Connection ID Sequence Number in network byte order,
+significant 32 bits of the Path Identifier in network byte order,
 two zero bits, and the 62 bits of the reconstructed QUIC packet number in
 network byte order. If the IV is larger than 96 bits, the path-and-packet-number
 is left-padded with zeros to the size of the IV. The exclusive OR of the padded
 packet number and the IV forms the AEAD nonce.
 
 For example, assuming the IV value is `6b26114b9cba2b63a9e8dd4f`,
-the Connection ID Sequence Number is `3`, and the packet number is `aead`,
+the Path Identifier is `3`, and the packet number is `aead`,
 the nonce will be set to `6b2611489cba2b63a9e873e2`.
 
 Due to the way the nonce is constructed, endpoints MUST NOT use more than 2^32

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -319,7 +319,9 @@ is used to identify the path in ACK_MP frames {#ack-mp-frame}.
 Note that the Path Identifier for the initial path is 0. Connection IDs
 which are issued by origin NEW_CONNECTION_ID frames {{Section 19.15. of QUIC-TRANSPORT}}
 MUST be treated as their Path Identifier is 0. Also, the Path Identifier for 
-the connection ID specified in the "preferred address" transport parameter is 1.
+the connection ID specified in the "preferred address" transport parameter is 0.
+Use of the "preferred address" is considered as a migration event
+that does not change the path ID.
 
 Endpoints use PATH_ABANDON frame to inform the peer of the retirement of associated 
 Path Identifier. When there is not enough unused Path Identifiers, endpoints SHOULD

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1300,9 +1300,9 @@ MP_NEW_CONNECTION_ID frames are formatted as shown in {{fig-mp-connection-id-fra
 ~~~
 MP_NEW_CONNECTION_ID Frame {
   Type (i) = 0x15228c09,
+  Path Identifier (i),
   Sequence Number (i),
   Retire Prior To (i),
-  Path Identifier (i),
   Length (8),
   Connection ID (8..160),
   Stateless Reset Token (128),

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -556,8 +556,7 @@ with Path Identifier 0.
 When the endpoint wishes to remove a connection ID from use, it sends 
 a MP_RETIRE_CONNECTION_ID frame {{mp-retire-conn-id-frame}} to its peer. 
 Sending a MP_RETIRE_CONNECTION_ID frame indicates that the connection ID 
-will not be used again and requests that the peer replace it with a new connection ID 
-using a MP_NEW_CONNECTION_ID frame.
+will not be used again. If the path is still active, the peer SHOULD replace it with a new connection ID using a MP_NEW_CONNECTION_ID frame.
 
 Note that Connection Sequeunce number and Retire Prior To field are both used for 
 the corresponding path specified by a Path Identifier. 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -881,7 +881,7 @@ Client                                                      Server
                <-1-RTT[Y]: DCID=C1 PATH_ABANDON[PathID=2],
                                                ACK_MP[PID=2, PN=X]
 (client retires the corresponding CID)
-1-RTT[U]: DCID=S3 RETIRE_CONNECTION_ID[2], ACK_MP[PID=1, PN=Y] ->
+1-RTT[U]: DCID=S3 MP_RETIRE_CONNECTION_ID[PathId=2, Seq=0], ACK_MP[PID=1, PN=Y] ->
                             (server retires the corresponding CID)
  <- 1-RTT[V]: DCID=C2 RETIRE_CONNECTION_ID[1], ACK_MP[PID=3, PN=U]
 ~~~

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -225,7 +225,7 @@ new Connection IDs with associating Path Identifiers before initiating new paths
 The Path Identifier communicated when advertising a
 Destination Connection ID is used to associate a packet to a packet number space 
 that is used on a valid path. Further, the
-Path Identifier of Destination Connection ID is used as numerical identifier
+Path Identifier associated with Destination Connection ID is used as numerical identifier
 in control frames. E.g. an endpoint sends a PATH_ABANDON frame to request its peer to
 abandon the path on which the sender uses the Path Identifier contained in the PATH_ABANDON frame.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -534,8 +534,9 @@ peer during the address validation procedure. According to
 {{QUIC-TRANSPORT}}, the standard way to deny the establishment of a path
 is to not send a PATH_RESPONSE in response to the peer's PATH_CHALLENGE.
 
-If endpoint fails to validate a path and consume an available Path Identifier,
-it SHOULD send a PATH_ABANDON frame to retire the associated Path Identifier. 
+A failed path validation consumes the Path ID used for probing of this path.
+An endpoint MUST not use the same Path ID to probe a different path. Instead, it
+MUST send a PATH_ABANDON frame to retire the Path ID. 
 
 
 ### Allocating, Consuming and Retiring Connection IDs {#consume-retire-cid}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -782,7 +782,7 @@ and with the least significant 32 bits of the path identifier pre-allocated
 for the Destination Connection ID.
 
 {{mp-new-conn-id-frame}} encodes the Path Identifier for Connection IDs 
-as a variable-length integer, allowing values up to 2^62-1; 
+as a variable-length integer, allowing values up to 2^32-1; 
 in this specification, a range of less than 2^32-1
 values MUST be used before updating the packet protection key.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -296,7 +296,7 @@ TRANSPORT_PARAMETER error.
 
 # Path Identifier {#pathid}
 
-The explicit Path Identifier is an integer between 0 and 2^62 - 1. 
+The explicit Path Identifier is an integer between 0 and 2^32 - 1 (inclusive). 
 The Path Identifier is pre-allocated when endpoints provide new Connection IDs
 with MP_NEW_CONNECTION_ID frames {{mp-new-conn-id-frame}}.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -307,7 +307,7 @@ with MP_NEW_CONNECTION_ID frames {{mp-new-conn-id-frame}}.
 Each Connection ID is associated with a Path Identifier, as documented in {{mp-new-conn-id-frame}}. 
 Multiple connection IDs can be associated with the same path identifier.
 
-Endpoints use Path Identifier to address a path in the multi-path control frames,
+Endpoints use Path Identifier to address a path in the multipath control frames,
 such as PATH_ABANDON, PATH_STANDBY, and PATH_AVAILABLE frames.
 
 Each endpoint associates a Receiver Packet Number space to each Path Identifier 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -254,8 +254,7 @@ defined as follows:
   a variable-length integer value specifying the maximum number of active concurrent paths an endpoint is 
   willing to build. The value of the max_concurrent_paths parameter MUST 
   be at least 2. An endpoint that receives a value less than 2 MUST close 
-  the connection with an error of type TRANSPORT_PARAMETER_ERROR. If this 
-  transport parameter is absent, a default of 4 is assumed. After the handshake 
+  the connection with an error of type TRANSPORT_PARAMETER_ERROR. After the handshake 
   negotiation finished, endpoints MUST use the minimum of local and remote
   value of max_concurrent_paths as the maximum number of paths in the current
   connection. 
@@ -1441,8 +1440,8 @@ TBD-00 - TBD-01 (experiments use 0x15228c00-0x15228c01) | ACK_MP              | 
 TBD-02 (experiments use 0x15228c05)                  | PATH_ABANDON        | {{path-abandon-frame}}
 TBD-03 (experiments use 0x15228c07)                  | PATH_STANDBY        | {{path-standby-frame}}
 TBD-04 (experiments use 0x15228c08)                  | PATH_AVAILABLE      | {{path-available-frame}}
-TBD-05 (experiments use 0x15228c09)                     | MP_NEW_CONNECTION_ID   | {{mp-new-conn-id-frame}}
-TBD-06 (experiments use 0x15228c0a)                     | MP_RETIRE_CONNECTION_ID| {{mp-retire-conn-id-frame}}
+TBD-05 (experiments use 0x15228c09)                  | MP_NEW_CONNECTION_ID   | {{mp-new-conn-id-frame}}
+TBD-06 (experiments use 0x15228c0a)                  | MP_RETIRE_CONNECTION_ID| {{mp-retire-conn-id-frame}}
 {: #frame-types title="Addition to QUIC Frame Types Entries"}
 
 The following transport error code defined in {{tab-error-code}} should

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1241,6 +1241,53 @@ a PATH_RESPONSE frame in order to indicate the preferred path usage
 before or during path initiation.
 
 
+## MP_NEW_CONNECTION_ID frames {#mp-new-conn-id-frame}
+
+An endpoint sends a MP_NEW_CONNECTION_ID frame (type=0x15228c09) instead of the NEW_CONNECTION_ID frame to provide its peer with alternative connection IDs that can be used to break linkability when migrating connections; see {{Section 19.15 of QUIC-TRANSPORT}}.
+
+MP_NEW_CONNECTION_ID frames are formatted as shown in {{fig-mp-connection-id-frame-format}}.
+
+~~~
+MP_NEW_CONNECTION_ID Frame {
+  Type (i) = 0x15228c09,
+  Sequence Number (i),
+  Retire Prior To (i),
+  Length (8),
+  Connection ID (8..160),
+  Stateless Reset Token (128),
+  Path Identifier (i),
+}
+~~~
+{: #fig-mp-connection-id-frame-format title="MP_NEW_CONNECTION_ID Frame Format"}
+
+MP_NEW_CONNECTION_ID frames contain the following fields:
+
+Path Identifier:
+: A path identifier which is pre allocated when the Connection ID is generated, which
+means the current Connection ID can only be used on the corresponding path.
+
+
+
+## MP_RETIRE_CONNECTION_ID frames {#mp-retire-conn-id-frame}
+
+An endpoint sends a MP_RETIRE_CONNECTION_ID frame (type=0x15228c0a) instead of RETIRE_CONNECTION_ID frame to indicate that it will no longer use a connection ID that was issued by its peer. This includes the connection ID provided during the handshake. Sending a MP_RETIRE_CONNECTION_ID frame also serves as a request to the peer to send additional connection IDs for future use. New connection IDs can be delivered to a peer using the MP_NEW_CONNECTION_ID frame ({{mp-new-conn-id-frame}}).
+
+Retiring a connection ID invalidates the stateless reset token associated with that connection ID.
+
+MP_RETIRE_CONNECTION_ID frames are formatted as shown in {{fig-mp-retire-connection-id-frame-format}}.
+
+~~~
+RETIRE_CONNECTION_ID Frame {
+  Type (i) = 0x15228c0a,
+  Sequence Number (i),
+  Path Identifier (i),
+}
+~~~
+{: #fig-mp-retire-connection-id-frame-format title="MP_RETIRE_CONNECTION_ID Frame Format"}
+
+
+
+
 # Error Codes {#error-codes}
 Multipath QUIC transport error codes are 62-bit unsigned integers
 following {{QUIC-TRANSPORT}}.


### PR DESCRIPTION
As the design required revision of the entire draft, this PR attempts to be a start point.