### PR TITLE
[+] Explicit Path ID: Clarify that endpoints use the same Path ID in both directions.

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -370,6 +370,10 @@ it MUST pick a Connection ID with the same path ID for sending the PATH_RESPONSE
 If validation succeeds, the client can continue to use the path.
 If validation fails, the client MUST NOT use the path and can
 remove any status associated to the path initation attempt.
+However, as the used Path ID is anyway consumed,
+and the endpoint MUST abandon the path by sending a PATH_ABANDON frame
+on another path to inform the peer that the Path ID cannot be used anymore.
+
 {{Section 9.1 of QUIC-TRANSPORT}} introduces the concept of
 "probing" and "non-probing" frames. When the multipath extension
 is negotiated, the reception of "non-probing"
@@ -452,10 +456,6 @@ the only way for an endhost to detect path closure (see
 
 PATH_ABANDON frame causes all CIDs allocated by both
 of the endpoints for the specified Path ID to be retired.
-
-When path validation of a new path fails, the used Path ID is anyway consumed,
-and the endpoint MUST abandon the path by sending a PATH_ABANDON frame
-on another path to inform the peer that the Path ID cannot be used anymore.
 
 Note that other explicit closing mechanisms of {{QUIC-TRANSPORT}} still
 apply on the whole connection. In particular, the reception of either a

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -490,10 +490,7 @@ the only way for an endhost to detect path closure (see
 
 PATH_ABANDON frame causes all the CID allocated for the specified Path ID to be retired.
 
-There is a special case that endpoints SHOULD send PATH_ABANDON frame:  
-When a client create a new path, it chooses a new Path ID and sends a Path Challenge 
-with a chosen Connection ID of that path. If it doesn’t receive any PATH_RESPONSE,
-it SHOULD consider the Path ID as consumed, and also SHOULD send a PATH_ABANDON frame
+When path validation of a new path fails, the client MUST consider the Path ID as consumed, and MUST abandon the path by sending a PATH_ABANDON frame.
 to inform the server that the Path ID can’t be used in the future.
 
 Note that other explicit closing mechanisms of {{QUIC-TRANSPORT}} still

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -360,7 +360,7 @@ Opening a new path requires the
 use of a new connection ID (see {{Section 9.5 of QUIC-TRANSPORT}}).
 Instead of NEW_CONNECTION_ID frame as specified in {{QUIC-TRANSPORT}},
 each endpoint uses MP_NEW_CONNECTION_ID frames
-to issue Path ID-specific connections IDs. 
+to issue Path ID-specific connections IDs.
 The same Path ID is used in both directions. As such to open
 a new path, both sides need at least
 one connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -487,7 +487,7 @@ However, implicit signals such as idle time or packet losses might be
 the only way for an endhost to detect path closure (see
 {{idle-time-close}}).
 
-PATH_ABANDON frame causes all the CID allocated for the specified Path ID to be retired.
+PATH_ABANDON frame causes all CID allocated by both of the endpoints for the specified Path ID to be retired.
 
 When path validation of a new path fails, the client MUST consider the Path ID as consumed, and MUST abandon the path by sending a PATH_ABANDON frame.
 to inform the server that the Path ID can’t be used in the future.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -129,7 +129,7 @@ parameter, as specified in {{nego}}.
 
 This extension specifies a new Path Identifier (Path ID), which is an
 integer between 0 and 2^32 - 1 (inclusive). Path identifies are generated
-monotonically increasing and cannot be reused. 
+monotonically increasing and cannot be reused.
 
 The same Path ID is used in both directions to
 address a path in the new multipath control frames,

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -129,15 +129,15 @@ parameter, as specified in {{nego}}.
 
 This extension specifies a new Path Identifier (Path ID), which is an
 integer between 0 and 2^32 - 1 (inclusive). Path identifies are generated
-monotonically increasing and cannot be reused.
+monotonically increasing and cannot be reused. 
 
-The Path ID is used to
+The same Path ID is used in both directions to
 address a path in the new multipath control frames,
 such as PATH_ABANDON {{path-abandon-frame}}, PATH_STANDBY {{path-standby-frame}}},
 PATH_AVAILABLE {{path-available-frame}} as well as ACK_MP {{ack-mp-frame}}.
 Further, connection IDs are issued per Path ID.
-Each connection ID is associated with one path identifier
-but multiple connection IDs can be associated with the same path identifier.
+That means each connection ID is associated with exactly one path identifier
+but multiple connection IDs are usually issued for each path identifier.
 
 The Path ID of the initial path is 0. Connection IDs
 which are issued by a NEW_CONNECTION_ID frame {{Section 19.15. of QUIC-TRANSPORT}}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -360,17 +360,11 @@ Opening a new path requires the
 use of a new connection ID (see {{Section 9.5 of QUIC-TRANSPORT}}).
 Instead of NEW_CONNECTION_ID frame as specified in {{QUIC-TRANSPORT}},
 each endpoint uses MP_NEW_CONNECTION_ID frames
-to issue usable Path ID-specific connections IDs to reach it. As such to open
-a new path by initiating path validation, both sides need at least
+to issue Path ID-specific connections IDs. 
+The same Path ID is used in both directions. As such to open
+a new path, both sides need at least
 one connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated
-with an unused Path ID.
-
-The same Path ID is used in both directions.
-The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
-An endpoint decides which Path ID is used for the new path
-by picking one of the peer-allocated CID with the specified Path ID.
-Then, the endpoint sends a PATH_CHALLENGE with the chosen CID. 
-If the peer receives the PATH_CHALLENGE,
+with the same, unused Path ID. If the peer receives the PATH_CHALLENGE,
 it MUST pick a Connection ID with the same path ID for sending the PATH_RESPONSE.
 
 If validation succeeds, the client can continue to use the path.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -489,8 +489,9 @@ the only way for an endhost to detect path closure (see
 
 PATH_ABANDON frame causes all CID allocated by both of the endpoints for the specified Path ID to be retired.
 
-When path validation of a new path fails, the client MUST consider the Path ID as consumed, and MUST abandon the path by sending a PATH_ABANDON frame.
-to inform the server that the Path ID can’t be used in the future.
+When path validation of a new path fails, the used Path ID is anyway consumed, 
+and the endpoint MUST abandon the path by sending a PATH_ABANDON frame
+on another path to inform the peer that the Path ID cannot be used anymore.
 
 Note that other explicit closing mechanisms of {{QUIC-TRANSPORT}} still
 apply on the whole connection. In particular, the reception of either a

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -383,18 +383,6 @@ All new frames are sent in 1-RTT packets {{QUIC-TRANSPORT}}.
 
 ## Path Initiation
 
-Connection IDs cannot be reused, thus opening a new path requires the
-use of a new Connection ID (see {{Section 9.5 of QUIC-TRANSPORT}}).
-Following {{QUIC-TRANSPORT}}, each endpoint uses MP_NEW_CONNECTION_ID frames
-to issue usable connections IDs to reach it. As such to open
-a new path by initiating path validation, both sides need at least
-one Connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated with an unused Path ID.
-
-If the transport parameter "initial_max_paths" is negotiated as N,
-and the client is already actively using N paths, the limit is reached.
-If the client wants to start a new path, it has to retire one of
-the established paths.
-
 When the multipath option is negotiated, clients that want to use an
 additional path MUST first initiate the Address Validation procedure
 with PATH_CHALLENGE and PATH_RESPONSE frames described in
@@ -403,6 +391,26 @@ that address. After receiving packets from the
 client on a new path, if the server decides to use the new path,
 the server MUST perform path validation ({{Section 8.2 of QUIC-TRANSPORT}})
 unless it has previously validated that address.
+
+If the transport parameter "initial_max_paths" is negotiated as N,
+and the client is already actively using N paths, the limit is reached.
+If the client wants to start a new path, it has to retire one of
+the established paths.
+
+Connection IDs cannot be reused, thus opening a new path requires the
+use of a new Connection ID (see {{Section 9.5 of QUIC-TRANSPORT}}).
+Following {{QUIC-TRANSPORT}}, each endpoint uses MP_NEW_CONNECTION_ID frames
+to issue usable connections IDs to reach it. As such to open
+a new path by initiating path validation, both sides need at least
+one Connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated with an unused Path ID.
+
+Endpoints use the same Path ID for one specific path in both directions.
+The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
+An endpoint decides which Path ID is used for the new path
+by picking one of the peer-allocated CID with the specified Path ID.
+Then, the endpoint sends a PATH_CHALLENGE with the chosen CID. 
+If the peer receives the PATH_CHALLENGE,
+it MUST pick a Connection ID with the same path ID for sending the PATH_RESPONSE.
 
 If validation succeeds, the client can continue to use the path.
 If validation fails, the client MUST NOT use the path and can

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -472,7 +472,7 @@ When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
 least three times the current Probe Timeout (PTO) interval after the last
 packet was sent on the path, as defined in {{Section 6.2 of QUIC-RECOVERY}},
 before sending MP_RETIRE_CONNECTION_ID frames.
-This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
+This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}.
 Both endpoints SHOULD send MP_RETIRE_CONNECTION_ID frames
 for all connection IDs associated to the Path ID of the abandoned path.
 to ensure that paths close cleanly and that delayed or reordered packets

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -469,9 +469,9 @@ by sending a PATH_ABANDON frame (see {{path-abandon-frame}}) which
 requests the peer to stop sending packets with the corresponding Path Identifier.
 
 When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
-least three times the current Probe Timeout (PTO) interval as defined in
-{{Section 6.2 of QUIC-RECOVERY}} after the last packet was sent on the path,
-before sending the MP_RETIRE_CONNECTION_ID frame for all the corresponding Connection
+least three times the current Probe Timeout (PTO) interval after the last
+packet was sent on the path, as defined in {{Section 6.2 of QUIC-RECOVERY}},
+before sending the MP_RETIRE_CONNECTION_ID frame for all the corresponding connection
 IDs used for this path. This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -471,8 +471,10 @@ requests the peer to stop sending packets with the corresponding Path Identifier
 When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
 least three times the current Probe Timeout (PTO) interval after the last
 packet was sent on the path, as defined in {{Section 6.2 of QUIC-RECOVERY}},
-before sending the MP_RETIRE_CONNECTION_ID frame for all the corresponding connection
-IDs used for this path. This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
+before sending MP_RETIRE_CONNECTION_ID frames.
+This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}
+Both endpoints SHOULD send MP_RETIRE_CONNECTION_ID frames
+for all connection IDs associated to the Path ID of the abandoned path.
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.
 The effect of receiving a MP_RETIRE_CONNECTION_ID frame is specified in the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -474,7 +474,7 @@ packet was sent on the path, as defined in {{Section 6.2 of QUIC-RECOVERY}},
 before sending MP_RETIRE_CONNECTION_ID frames.
 This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}.
 Both endpoints SHOULD send MP_RETIRE_CONNECTION_ID frames
-for all connection IDs associated to the Path ID of the abandoned path.
+for all connection IDs associated to the Path ID of the abandoned path
 to ensure that paths close cleanly and that delayed or reordered packets
 are properly discarded.
 The effect of receiving a MP_RETIRE_CONNECTION_ID frame is specified in the

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -454,9 +454,6 @@ However, implicit signals such as idle time or packet losses might be
 the only way for an endhost to detect path closure (see
 {{idle-time-close}}).
 
-When a path is abandoned, all CIDs allocated by both
-of the endpoints for the specified Path ID need to be retired.
-
 Note that other explicit closing mechanisms of {{QUIC-TRANSPORT}} still
 apply on the whole connection. In particular, the reception of either a
 CONNECTION_CLOSE ({{Section 10.2 of QUIC-TRANSPORT}}) or a Stateless
@@ -467,18 +464,6 @@ Reset ({{Section 10.3 of QUIC-TRANSPORT}}) closes the connection.
 Both endpoints, namely the client and the server, can initiate path closure,
 by sending a PATH_ABANDON frame (see {{path-abandon-frame}}) which
 requests the peer to stop sending packets with the corresponding Path Identifier.
-
-When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
-least three times the current Probe Timeout (PTO) interval after the last
-packet was sent on the path, as defined in {{Section 6.2 of QUIC-RECOVERY}},
-before sending MP_RETIRE_CONNECTION_ID frames.
-This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}.
-Both endpoints SHOULD send MP_RETIRE_CONNECTION_ID frames
-for all connection IDs associated to the Path ID of the abandoned path
-to ensure that paths close cleanly and that delayed or reordered packets
-are properly discarded.
-The effect of receiving a MP_RETIRE_CONNECTION_ID frame is specified in the
-next section.
 
 Usually, it is expected that the PATH_ABANDON frame is used by the client
 to indicate to the server that path conditions have changed such that
@@ -491,6 +476,20 @@ connection ID used on that path anymore.
 The receiver of a PATH_ABANDON frame MAY also send
 a PATH_ABANDON frame to indicate its own unwillingness to receive
 any packet on this path anymore.
+
+When a path is abandoned, all CIDs allocated by both
+of the endpoints for the specified Path ID need to be retired.
+When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
+least three times the current Probe Timeout (PTO) interval after the last
+packet was sent on the path, as defined in {{Section 6.2 of QUIC-RECOVERY}},
+before sending MP_RETIRE_CONNECTION_ID frames.
+This is inline with the requirement of {{Section 10.2 of QUIC-TRANSPORT}}.
+Both endpoints SHOULD send MP_RETIRE_CONNECTION_ID frames
+for all connection IDs associated to the Path ID of the abandoned path
+to ensure that paths close cleanly and that delayed or reordered packets
+are properly discarded.
+The effect of receiving a MP_RETIRE_CONNECTION_ID frame is specified in the
+next section.
 
 PATH_ABANDON frames can be sent on any path,
 not only the path that is intended to be closed. Thus, a path can
@@ -510,8 +509,8 @@ CONNECTION_CLOSE frame.
 
 Note that PATH_ABANDON frame is also used as a signal for the retirement
 of the associated Path Identifier. When endpoint received PATH_ABANDON frame,
-it SHOULD not use the associated Path Identifier in future packets, it can
-only use the Path ID in ACK_MP frames for inflight packets or
+it SHOULD NOT use the associated Path Identifier in future packets, except
+in ACK_MP frames for inflight packets or
 in MP_RETIRE_CONNECTION_ID frames for CID retirement.
 
 ### Refusing a New Path

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -320,8 +320,7 @@ it picks one of the server allocated CID with the specified Path ID.
 Then the client send a PATH_CHALLENGE with the chosen CID. If the server receives the PATH_CHALLENGE, 
 it picks a Connection ID with the same path ID for sending the PATH_RESPONSE.
 
-The client SHOULD choose a new Path ID which is not used in previous paths, 
-and both endpoints have already issued unused CIDs with the new Path ID.
+The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
 If the server receives a PATH_CHALLENGE before receiving MP_NEW_CONNECTION_ID 
 for the specify path, it MAY choose to ignore the PATH_CHALLENGE, or it can
 choose to send PATH_RESPONSE until it receives the MP_NEW_CONNECTION_ID containing

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -314,13 +314,13 @@ to each Path Identifier received from the peer.
 
 
 Endpoints use the same Path ID for one specific path in both directions.
-For a client-initiated path, the client decides which Path ID used for the new path,
-it picks one of the server allocated CID with the specified Path ID.
-Then the client send a PATH_CHALLENGE with the chosen CID. If the server receives the PATH_CHALLENGE,
+For a client-initiated path, the client decides which Path ID is used for the new path
+by picking one of the server allocated CID with the specified Path ID.
+Then, the client sends a PATH_CHALLENGE with the chosen CID. If the server receives the PATH_CHALLENGE,
 it picks a Connection ID with the same path ID for sending the PATH_RESPONSE.
 
 The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
-If the server receives a PATH_CHALLENGE before receiving MP_NEW_CONNECTION_ID
+If the server receives a PATH_CHALLENGE before receiving a MP_NEW_CONNECTION_ID
 for the specific path, it MAY choose to ignore the PATH_CHALLENGE, or it can
 choose to send the PATH_RESPONSE frame upon reception of a
 MP_NEW_CONNECTION_ID frame containing the corresponding Path ID.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -514,7 +514,6 @@ probing packet is received on a new path before sending the
 CONNECTION_CLOSE frame.
 
 
-
 ### Refusing a New Path
 
 An endpoint may deny the establishment of a new path initiated by its

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -322,7 +322,7 @@ it picks a Connection ID with the same path ID for sending the PATH_RESPONSE.
 
 The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
 If the server receives a PATH_CHALLENGE before receiving MP_NEW_CONNECTION_ID 
-for the specify path, it MAY choose to ignore the PATH_CHALLENGE, or it can
+for the specific path, it MAY choose to ignore the PATH_CHALLENGE, or it can
 choose to send PATH_RESPONSE until it receives the MP_NEW_CONNECTION_ID containing
 the corresponding Path ID arrives.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -489,7 +489,7 @@ the only way for an endhost to detect path closure (see
 
 PATH_ABANDON frame causes all CID allocated by both of the endpoints for the specified Path ID to be retired.
 
-When path validation of a new path fails, the used Path ID is anyway consumed, 
+When path validation of a new path fails, the used Path ID is anyway consumed,
 and the endpoint MUST abandon the path by sending a PATH_ABANDON frame
 on another path to inform the peer that the Path ID cannot be used anymore.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -454,8 +454,8 @@ However, implicit signals such as idle time or packet losses might be
 the only way for an endhost to detect path closure (see
 {{idle-time-close}}).
 
-PATH_ABANDON frame causes all CIDs allocated by both
-of the endpoints for the specified Path ID to be retired.
+When a path is abandoned, all CIDs allocated by both
+of the endpoints for the specified Path ID need to be retired.
 
 Note that other explicit closing mechanisms of {{QUIC-TRANSPORT}} still
 apply on the whole connection. In particular, the reception of either a

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1228,8 +1228,7 @@ PATH_ABANDON frames are formatted as shown in {{fig-path-abandon-format}}.
 PATH_ABANDON frames contain the following fields:
 
 Path Identifier:
-: The Path Identifier of the Destination Connection ID used by the
-  receiver of the frame to send packets over the path to abandon.
+: The Path Identifier to abandon.
 
 Error Code:
 : A variable-length integer that indicates the reason for abandoning
@@ -1271,9 +1270,8 @@ PATH_STANDBY frames are formatted as shown in {{fig-path-standby-format}}.
 PATH_STANDBY Frames contain the following fields:
 
 Path Identifier:
-: The Path Identifier of the Destination Connection ID used by the
-  receiver of this frame to send packets over the path the status update
-  corresponds to. All Destination Connection IDs that have been issued
+: The Path Identifier the status update corresponds to.
+  All Destination Connection IDs that have been issued
   MAY be specified, even if they are not yet in use over a path.
 
 Path Status sequence number:
@@ -1321,9 +1319,7 @@ PATH_AVAILABLE frames are formatted as shown in {{fig-path-available-format}}.
 PATH_AVAILABLE frames contain the following fields:
 
 Path Identifier:
-: The Path Identifier of the Destination Connection ID used by the
-  receiver of this frame to send packets over the path the status update
-  corresponds to.
+: The Path Identifier the status update corresponds to.
 
 Path Status sequence number:
 : A variable-length integer specifying

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -456,7 +456,8 @@ However, implicit signals such as idle time or packet losses might be
 the only way for an endhost to detect path closure (see
 {{idle-time-close}}).
 
-PATH_ABANDON frame causes all CID allocated by both of the endpoints for the specified Path ID to be retired.
+PATH_ABANDON frame causes all CIDs allocated by both
+of the endpoints for the specified Path ID to be retired.
 
 When path validation of a new path fails, the used Path ID is anyway consumed,
 and the endpoint MUST abandon the path by sending a PATH_ABANDON frame

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -323,8 +323,8 @@ it picks a Connection ID with the same path ID for sending the PATH_RESPONSE.
 The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
 If the server receives a PATH_CHALLENGE before receiving MP_NEW_CONNECTION_ID 
 for the specific path, it MAY choose to ignore the PATH_CHALLENGE, or it can
-choose to send PATH_RESPONSE until it receives the MP_NEW_CONNECTION_ID containing
-the corresponding Path ID arrives.
+choose to send the PATH_RESPONSE frame upon reception of a
+MP_NEW_CONNECTION_ID frame containing the corresponding Path ID.
 
 The Path Identifier associated with the Destination Connection ID is used to 
 construct the packet protection nonce defined in {#multipath-aead}.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -365,7 +365,7 @@ a new path by initiating path validation, both sides need at least
 one connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated
 with an unused Path ID.
 
-Endpoints use the same Path ID for one specific path in both directions.
+The same Path ID is used in both directions.
 The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
 An endpoint decides which Path ID is used for the new path
 by picking one of the peer-allocated CID with the specified Path ID.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -313,14 +313,14 @@ that it provides to the peer. Each endpoint associates a Sender Packet Number sp
 to each Path Identifier received from the peer.
 
 
-Endpoints use the same Path ID for one specific path in both directions. 
-For a client-initiated path, the client decides which Path ID used for the new path, 
-it picks one of the server allocated CID with the specified Path ID. 
-Then the client send a PATH_CHALLENGE with the chosen CID. If the server receives the PATH_CHALLENGE, 
+Endpoints use the same Path ID for one specific path in both directions.
+For a client-initiated path, the client decides which Path ID used for the new path,
+it picks one of the server allocated CID with the specified Path ID.
+Then the client send a PATH_CHALLENGE with the chosen CID. If the server receives the PATH_CHALLENGE,
 it picks a Connection ID with the same path ID for sending the PATH_RESPONSE.
 
 The client MUST choose a previously unused Path ID for which both endpoints have already issued at least one connection ID.
-If the server receives a PATH_CHALLENGE before receiving MP_NEW_CONNECTION_ID 
+If the server receives a PATH_CHALLENGE before receiving MP_NEW_CONNECTION_ID
 for the specific path, it MAY choose to ignore the PATH_CHALLENGE, or it can
 choose to send the PATH_RESPONSE frame upon reception of a
 MP_NEW_CONNECTION_ID frame containing the corresponding Path ID.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -477,6 +477,18 @@ The receiver of a PATH_ABANDON frame MAY also send
 a PATH_ABANDON frame to indicate its own unwillingness to receive
 any packet on this path anymore.
 
+The PATH_ABANDON frame is retires the associated Path Identifier.
+When an endpoint receives a PATH_ABANDON frame,
+it SHOULD NOT use the associated Path Identifier in future packets, except
+in ACK_MP frames for inflight packets and
+in MP_RETIRE_CONNECTION_ID frames for CID retirement.
+
+PATH_ABANDON frames can be sent on any path,
+not only the path that is intended to be closed. Thus, a path can
+be abandoned even if connectivity on that path is already broken.
+Respectively, if there is still an active path, it is RECOMMENDED to
+send a PATH_ABANDON frame after an idle time on another path.
+
 When a path is abandoned, all CIDs allocated by both
 of the endpoints for the specified Path ID need to be retired.
 When sending or receiving a PATH_ABANDON frame, endpoints SHOULD wait for at
@@ -491,12 +503,6 @@ are properly discarded.
 The effect of receiving a MP_RETIRE_CONNECTION_ID frame is specified in the
 next section.
 
-PATH_ABANDON frames can be sent on any path,
-not only the path that is intended to be closed. Thus, a path can
-be abandoned even if connectivity on that path is already broken.
-Respectively, if there is still an active path, it is RECOMMENDED to
-send a PATH_ABANDON frame after an idle time on another path.
-
 If a PATH_ABANDON frame is received for the only active path of a QUIC
 connection, the receiving peer SHOULD send a CONNECTION_CLOSE frame
 and enter the closing state. If the client received a PATH_ABANDON
@@ -507,11 +513,7 @@ the server MAY wait for a short, limited time such as one PTO if a path
 probing packet is received on a new path before sending the
 CONNECTION_CLOSE frame.
 
-Note that PATH_ABANDON frame is also used as a signal for the retirement
-of the associated Path Identifier. When endpoint received PATH_ABANDON frame,
-it SHOULD NOT use the associated Path Identifier in future packets, except
-in ACK_MP frames for inflight packets or
-in MP_RETIRE_CONNECTION_ID frames for CID retirement.
+
 
 ### Refusing a New Path
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -314,6 +314,14 @@ Each endpoint associates a Receiver Packet Number space to each Path Identifier
 that it provides to the peer. Each endpoint associates a Sender Packet Number space 
 to each Path Identifier received from the peer.
 
+Endpoints use the same Path ID for one specific path in both directions. 
+For a client-initiated path, the client decides which Path ID used for the new path, 
+and it picks one of the server allocated CID with the specified Path ID. 
+The client SHOULD choose a new Path ID which is not used in previous paths, 
+and both endpoints have already issued unused CIDs with the new Path ID.
+The client then initializes a new path with a packet containing PATH_CHALLENGE and
+the Destination Connection ID with the chosen Path ID.
+
 The Path Identifier associated with the Destination Connection ID is used to 
 construct the packet protection nonce defined in {#multipath-aead}.
 


### PR DESCRIPTION
Solving issue #294 