### PR TITLE
Fix errors and warning related to references

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -52,14 +52,12 @@ author:
 
 
 normative:
-  RFC2119:
   QUIC-TRANSPORT: rfc9000
   QUIC-TLS: rfc9001
   QUIC-RECOVERY: rfc9002
 
 informative:
   RFC6356:
-  QUIC-Timestamp: I-D.huitema-quic-ts
   OLIA:
     title: "MPTCP is not pareto-optimal: performance issues and
 a possible solution"
@@ -130,7 +128,7 @@ requires negotiation between the two endpoints using a new transport
 parameter, as specified in {{nego}}.
 
 This extension uses multiple packet number spaces.
-When multipath is negotiated, each separate packet number space is linked to a path ID. 
+When multipath is negotiated, each separate packet number space is linked to a path ID.
 Using multiple packet number spaces enables direct use of the
 loss recovery and congestion control mechanisms defined in
 {{QUIC-RECOVERY}}.
@@ -187,13 +185,13 @@ We assume that the reader is familiar with the terminology used in
 to the notion of "network path" used in {{QUIC-TRANSPORT}}.
 In addition, we define the following term:
 
-- Path Identifier (Path ID): An identifier that is used to identify 
-  a path in a QUIC connection at an endpoint. Path Identifier is used 
-  in multipath control frames (etc. PATH_ABANDON frame) to identify a path. 
-  Connection IDs are issued per path ID. When endpoints address a path in 
+- Path Identifier (Path ID): An identifier that is used to identify
+  a path in a QUIC connection at an endpoint. Path Identifier is used
+  in multipath control frames (etc. PATH_ABANDON frame) to identify a path.
+  Connection IDs are issued per path ID. When endpoints address a path in
   multipath control frames, it refers to the Path Identifier related to
-  the destination Connection ID used for sending packets on that 
-  particular path. 
+  the destination Connection ID used for sending packets on that
+  particular path.
 
 
 # High-level overview {#overview}
@@ -208,13 +206,13 @@ See further {{nego}}.
 The peers use the initial_max_paths transport parameter during the handshake to
 negotiate the utilization of the multipath capabilities.
 The initial_max_paths transport parameter limits the initial maximum number of active paths
-that can be used during a connection. The active_connection_id_limit 
+that can be used during a connection. The active_connection_id_limit
 transport parameter limits the maximum number of active Connection IDs
 per path. A multipath QUIC connection is thus an established QUIC
 connection where the initial_max_paths transport parameter
 has been successfully negotiated.
 
-Endpoints need to pre-allocate new Connection IDs with associating Path Identifiers 
+Endpoints need to pre-allocate new Connection IDs with associating Path Identifiers
 before initiating new paths.
 To add a new path to an existing multipath QUIC connection, a client starts a path validation on
 the chosen path, as further described in {{setup}}.
@@ -222,9 +220,9 @@ In this version of the document, a QUIC server does not initiate the creation
 of a path, but it can validate a new path created by a client.
 A new path can only be used once the associated 4-tuple has been validated
 by ensuring that the peer is able to receive packets at that address
-(see {{Section 8 of QUIC-TRANSPORT}}). 
+(see {{Section 8 of QUIC-TRANSPORT}}).
 The Path Identifier communicated when advertising a
-Destination Connection ID is used to associate a packet to a packet number space 
+Destination Connection ID is used to associate a packet to a packet number space
 that is used on a valid path. Further, the
 Path Identifier associated with Destination Connection ID is used as numerical identifier
 in control frames. E.g. an endpoint sends a PATH_ABANDON frame to request its peer to
@@ -248,13 +246,13 @@ defined as follows:
 
 - initial_max_paths (current version uses 0x0f739bbc1b666d07): the
   initial_max_paths transport parameter is included if the endpoint supports
-  the multipath extension as defined in this document. This is 
-  a variable-length integer value specifying the maximum number of 
-  active concurrent paths an endpoint is willing to build. 
-  The value of the initial_max_paths parameter MUST be at least 2. 
-  An endpoint that receives a value less than 2 MUST close 
-  the connection with an error of type TRANSPORT_PARAMETER_ERROR. Setting 
-  this parameter is equivalent to sending a MAX_PATHS ({{max-paths-frame}}) 
+  the multipath extension as defined in this document. This is
+  a variable-length integer value specifying the maximum number of
+  active concurrent paths an endpoint is willing to build.
+  The value of the initial_max_paths parameter MUST be at least 2.
+  An endpoint that receives a value less than 2 MUST close
+  the connection with an error of type TRANSPORT_PARAMETER_ERROR. Setting
+  this parameter is equivalent to sending a MAX_PATHS ({{max-paths-frame}})
   of the corresponding type with the same value.
 
 If any of the endpoints does not advertise the initial_max_paths transport
@@ -277,15 +275,15 @@ defined in {{Section 18.2. of QUIC-TRANSPORT}}.
 
 The transport parameter "active_connection_id_limit"
 {{QUIC-TRANSPORT}} limits the number of usable Connection IDs per path when the
-initial_max_paths parameter is negotiated successfully. 
-Endpoints might prefer to retain spare Connection IDs so that they can 
-respond to unintentional migration events ({{Section 9.5 of QUIC-TRANSPORT}}). 
+initial_max_paths parameter is negotiated successfully.
+Endpoints might prefer to retain spare Connection IDs so that they can
+respond to unintentional migration events ({{Section 9.5 of QUIC-TRANSPORT}}).
 
-Endpoints SHOULD use MP_NEW_CONNECTION_ID and MP_RETIRE_CONNECTION_ID 
-frames to provide new Connection IDs for the peer after the initial_max_paths parameter is negotiated. 
+Endpoints SHOULD use MP_NEW_CONNECTION_ID and MP_RETIRE_CONNECTION_ID
+frames to provide new Connection IDs for the peer after the initial_max_paths parameter is negotiated.
 
-Endpoints MUST NOT issue Connection IDs with Path Identifiers larger than 
-the path limitation declared by the initial_max_paths transport parameter 
+Endpoints MUST NOT issue Connection IDs with Path Identifiers larger than
+the path limitation declared by the initial_max_paths transport parameter
 and MAX_PATHS frames.
 
 Cipher suites with nonce shorter than 12 bytes cannot be used together with
@@ -296,40 +294,40 @@ TRANSPORT_PARAMETER error.
 
 # Path Identifier {#pathid}
 
-The explicit Path Identifier is an integer between 0 and 2^32 - 1 (inclusive). 
+The explicit Path Identifier is an integer between 0 and 2^32 - 1 (inclusive).
 The Path Identifier is pre-allocated when endpoints provide new Connection IDs
 with MP_NEW_CONNECTION_ID frames {{mp-new-conn-id-frame}}.
 
-Each Connection ID is associated with a Path Identifier, as documented in {{mp-new-conn-id-frame}}. 
+Each Connection ID is associated with a Path Identifier, as documented in {{mp-new-conn-id-frame}}.
 Multiple connection IDs can be associated with the same path identifier.
 
 Endpoints use Path Identifier to address a path in the multipath control frames,
-such as PATH_ABANDON, PATH_STANDBY, and PATH_AVAILABLE frames. 
+such as PATH_ABANDON, PATH_STANDBY, and PATH_AVAILABLE frames.
 
-Path IDs are generated monotonically increasing, which means the retired Path IDs 
-MUST NOT be reused. Once a Path ID is retired by PATH_ABANDON, 
+Path IDs are generated monotonically increasing, which means the retired Path IDs
+MUST NOT be reused. Once a Path ID is retired by PATH_ABANDON,
 it MUST NOT be reused on any other path.
 
-Each endpoint associates a Receiver Packet Number space to each Path Identifier 
-that it provides to the peer. Each endpoint associates a Sender Packet Number space 
+Each endpoint associates a Receiver Packet Number space to each Path Identifier
+that it provides to the peer. Each endpoint associates a Sender Packet Number space
 to each Path Identifier received from the peer.
 
-The Path Identifier associated with the Destination Connection ID is used to 
+The Path Identifier associated with the Destination Connection ID is used to
 construct the packet protection nonce defined in {#multipath-aead}.
 
-The Path Identifier associated with the Destination Connection ID 
+The Path Identifier associated with the Destination Connection ID
 is used to identify the path in ACK_MP frames {#ack-mp-frame}.
 
 Note that the Path Identifier for the initial path is 0. Connection IDs
 which are issued by origin NEW_CONNECTION_ID frames {{Section 19.15. of QUIC-TRANSPORT}}
-MUST be treated as their Path Identifier is 0. Also, the Path Identifier for 
+MUST be treated as their Path Identifier is 0. Also, the Path Identifier for
 the connection ID specified in the "preferred address" transport parameter is 0.
 Use of the "preferred address" is considered as a migration event
 that does not change the path ID.
 
-Endpoints use PATH_ABANDON frame to inform the peer of the retirement of associated 
+Endpoints use PATH_ABANDON frame to inform the peer of the retirement of associated
 Path Identifier. When there is not enough unused Path Identifiers, endpoints SHOULD
-send MAX_PATHS frame to inform the peer that new Path Identifiers are available. 
+send MAX_PATHS frame to inform the peer that new Path Identifiers are available.
 
 
 # Path Setup and Removal {#setup}
@@ -353,7 +351,7 @@ does not discuss when a client decides to initiate a new path. We
 delegate such discussion in separate documents.
 
 To let the peer open a new path, an endpoint needs to provide its peer with connection IDs
-and associated Path Identifiers for the new path. 
+and associated Path Identifiers for the new path.
 
 To open a new path, an endpoint SHALL use different Connection IDs on different paths.
 Still, the receiver may observe the same Connection ID used on different
@@ -377,11 +375,11 @@ use of a new Connection ID (see {{Section 9.5 of QUIC-TRANSPORT}}).
 Following {{QUIC-TRANSPORT}}, each endpoint uses MP_NEW_CONNECTION_ID frames
 to issue usable connections IDs to reach it. As such to open
 a new path by initiating path validation, both sides need at least
-one Connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated with an unused Path ID. 
+one Connection ID (see {{Section 5.1.1 of QUIC-TRANSPORT}}), which is associated with an unused Path ID.
 
-If the transport parameter "initial_max_paths" is negotiated as N, 
-and the client is already actively using N paths, the limit is reached. 
-If the client wants to start a new path, it has to retire one of 
+If the transport parameter "initial_max_paths" is negotiated as N,
+and the client is already actively using N paths, the limit is reached.
+If the client wants to start a new path, it has to retire one of
 the established paths.
 
 When the multipath option is negotiated, clients that want to use an
@@ -451,7 +449,7 @@ Endpoints use Path Identifier
 in these frames to identify which path state is going to be
 changed. Notice that both frames can be sent via a different path
 and therefore might arrive in different orders.
-The PATH_AVAILABLE and PATH_STANDBY frames share a common sequence number space 
+The PATH_AVAILABLE and PATH_STANDBY frames share a common sequence number space
 to detect and ignore outdated information.
 
 If all available path are marked as "standby", no guidance is provided about
@@ -525,10 +523,10 @@ the server MAY wait for a short, limited time such as one PTO if a path
 probing packet is received on a new path before sending the
 CONNECTION_CLOSE frame.
 
-Note that PATH_ABANDON frame is also used as a signal for the retirement 
+Note that PATH_ABANDON frame is also used as a signal for the retirement
 of the associated Path Identifier. When endpoint received PATH_ABANDON frame,
-it SHOULD not use the associated Path Identifier in future packets, it can 
-only use the Path ID in ACK_MP frames for inflight packets or 
+it SHOULD not use the associated Path Identifier in future packets, it can
+only use the Path ID in ACK_MP frames for inflight packets or
 in MP_RETIRE_CONNECTION_ID frames for CID retirement.
 
 ### Refusing a New Path
@@ -540,38 +538,38 @@ is to not send a PATH_RESPONSE in response to the peer's PATH_CHALLENGE.
 
 A failed path validation consumes the Path ID used for probing of this path.
 An endpoint MUST not use the same Path ID to probe a different path. Instead, it
-MUST send a PATH_ABANDON frame to retire the Path ID. 
+MUST send a PATH_ABANDON frame to retire the Path ID.
 
 
 ### Allocating, Consuming and Retiring Connection IDs {#consume-retire-cid}
 
-Each endpoints pre-allocate a Path Identifier for each new Connection ID. 
-The Path Identifier 0 indicates the initial path of the connection. 
+Each endpoints pre-allocate a Path Identifier for each new Connection ID.
+The Path Identifier 0 indicates the initial path of the connection.
 Endpoints SHOULD issue at least one unused Connection ID with unused Path Identifier.
 
-An endpoint maintains a set of connection IDs received from its peer for each path, 
-any of which it can use when sending packets, as the same in {{QUIC-TRANSPORT}}. 
+An endpoint maintains a set of connection IDs received from its peer for each path,
+any of which it can use when sending packets, as the same in {{QUIC-TRANSPORT}}.
 The difference of multi-path extension is that Connection IDs are pre-allocated
 for each paths. Each Connection ID is belonging to one path specified by
 the Path Identifier field of MP_NEW_CONNECTION_ID frame in {{mp-new-conn-id-frame}}.
 The Connection IDs used during handshake are belonging to the initial path
 with Path Identifier 0.
 
-When the endpoint wishes to remove a connection ID from use, it sends 
-a MP_RETIRE_CONNECTION_ID frame {{mp-retire-conn-id-frame}} to its peer. 
-Sending a MP_RETIRE_CONNECTION_ID frame indicates that the connection ID 
+When the endpoint wishes to remove a connection ID from use, it sends
+a MP_RETIRE_CONNECTION_ID frame {{mp-retire-conn-id-frame}} to its peer.
+Sending a MP_RETIRE_CONNECTION_ID frame indicates that the connection ID
 will not be used again. If the path is still active, the peer SHOULD replace it with a new connection ID using a MP_NEW_CONNECTION_ID frame.
 
-Note that Connection Sequeunce number and Retire Prior To field are both used for 
-the corresponding path specified by a Path Identifier. 
+Note that Connection Sequeunce number and Retire Prior To field are both used for
+the corresponding path specified by a Path Identifier.
 
-Upon receipt of an increased Retire Prior To field, the peer MUST stop 
-using the corresponding connection IDs of the specified path and retire them 
-with MP_RETIRE_CONNECTION_ID frames before adding the newly provided connection ID 
+Upon receipt of an increased Retire Prior To field, the peer MUST stop
+using the corresponding connection IDs of the specified path and retire them
+with MP_RETIRE_CONNECTION_ID frames before adding the newly provided connection ID
 to the set of active connection IDs belonging to the specified path.
 
-Endpoints MUST NOT issue new Connection IDs which has Path Identifiers larger than 
-the max path identifier field in MP_MAX_PATHS frames {{max-paths-frame}}. 
+Endpoints MUST NOT issue new Connection IDs which has Path Identifiers larger than
+the max path identifier field in MP_MAX_PATHS frames {{max-paths-frame}}.
 When endpoint finds it has not enough available unused Path Identifiers,
 it SHOULD send a MP_MAX_PATHS frame to inform the peer that it could use larger active
 Path Identifiers.
@@ -580,9 +578,9 @@ Path Identifiers.
 ### Effect of MP_RETIRE_CONNECTION_ID Frame {#retire-cid-close}
 
 Receiving a MP_RETIRE_CONNECTION_ID frame causes an endpoint to discard
-the resources associated with that Connection ID. Note that retirement of 
+the resources associated with that Connection ID. Note that retirement of
 Connection IDs will not effect the use of Path Identifier for the specific path.
-The list of received packets used to send acknowledgements is also remain 
+The list of received packets used to send acknowledgements is also remain
 uneffected as the packet number space is associated with a path.
 
 The peer, that sent RETIRE_CONNECTION_ID frame, can keep sending data using
@@ -689,7 +687,7 @@ In non-final states, hosts have to track the following information.
 destination port) used by the endhost to send packets over the path.
 
 - Associated Path Identifier: The Path Identifier used to address the path.
-The endpoint relies on its sequence number to send path control information 
+The endpoint relies on its sequence number to send path control information
 and specifically acknowledge packets belonging to that path-specific
 packet number space.
 
@@ -699,7 +697,7 @@ packets over the path.
 In Active state, hosts MUST also track the following information:
 
 - Associated Source Connection ID: The Connection ID used to receive
-packets over the path. 
+packets over the path.
 
 A path in the "Validating" state performs path validation as described
 in {{Section 8.2 of QUIC-TRANSPORT}}.
@@ -782,11 +780,11 @@ the packet number alone would not guarantee the uniqueness of the nonce.
 
 In order to guarantee the uniqueness of the nonce, the nonce N is
 calculated by combining the packet protection IV with the packet number
-and with the least significant 32 bits of the path identifier pre-allocated 
+and with the least significant 32 bits of the path identifier pre-allocated
 for the Destination Connection ID.
 
-{{mp-new-conn-id-frame}} encodes the Path Identifier for Connection IDs 
-as a variable-length integer, allowing values up to 2^32-1; 
+{{mp-new-conn-id-frame}} encodes the Path Identifier for Connection IDs
+as a variable-length integer, allowing values up to 2^32-1;
 in this specification, a range of less than 2^32-1
 values MUST be used before updating the packet protection key.
 
@@ -883,14 +881,14 @@ the initial path.
 {{fig-example-path-close1}} illustrates an example of path closing. For the first path, the
 server's 1-RTT packets use DCID C1, which has a path identifier of 1; the
 client's 1-RTT packets use DCID S2, which has a path identifier of 2. For the
-second path, the server's 1-RTT packets use DCID C2, which has a path identifier of 2; 
+second path, the server's 1-RTT packets use DCID C2, which has a path identifier of 2;
 the client's 1-RTT packets use DCID S3, which has a path identifier
 of 3. Note that the paths use different packet number spaces. In this case, the
-client is going to close the first path. It identifies the path by the Path Identifier 
+client is going to close the first path. It identifies the path by the Path Identifier
 of the DCID its peer uses for sending packets over that path,
 hence using the DCID with path identifier 1 (which relates to C1). Optionally, the
-server confirms the path closure by sending an PATH_ABANDON frame 
-by indicating the path identifier the client uses to send over that path, 
+server confirms the path closure by sending an PATH_ABANDON frame
+by indicating the path identifier the client uses to send over that path,
 which corresponds to the path identifier 2 (of S2). Both the client and
 the server can close the path after receiving the RETIRE_CONNECTION_ID frame
 for that path.
@@ -911,10 +909,10 @@ Client                                                      Server
 {: #fig-example-path-close1 title="Example of closing a path."}
 
 After a path is abandoned, the Path Identifier associated with the path
-is considered retired and MUST NOT be reused in new paths for security 
-consideration {{multipath-aead}}. 
+is considered retired and MUST NOT be reused in new paths for security
+consideration {{multipath-aead}}.
 
-Endpoint SHOULD send MAX_PATHS frames {{max-paths-frame}} to raise 
+Endpoint SHOULD send MAX_PATHS frames {{max-paths-frame}} to raise
 the limit of Path Identifiers when endpoint finds there are not enough unused
 Path Identifiers (e.g. more than half of the available Path Identifiers
 are used).
@@ -935,7 +933,7 @@ model the relations between paths and number spaces, as shown
 in {{fig-number-spaces}}.
 
 ~~~
-   +-------------------------+             
+   +-------------------------+
    | CID received from peer: |-- - - - - - +
    | Sender Number Space     |             |
    +-------------------------+             v
@@ -948,7 +946,7 @@ in {{fig-number-spaces}}.
    +-------------------------+             ^
    | CID provided to peer:   |             |
    | Receiver Number Space   |-- - - - - - +
-   +-------------------------+  
+   +-------------------------+
 ~~~
 {: #fig-number-spaces title="Send and Receive number spaces"}
 
@@ -959,8 +957,8 @@ from the list of CID provided by the peer. Packets received
 on the path carry a Destination CID selected by the peer from
 the list provided to that peer.
 
-The relation between packet number spaces and paths is fixed. 
-CIDs are pre-allocated for each Path Identifier. Once CIDs are issued, 
+The relation between packet number spaces and paths is fixed.
+CIDs are pre-allocated for each Path Identifier. Once CIDs are issued,
 they are assigned to one specific Path Identifier. A node may
 decide to rotate the Destination CID it uses, a NAT may decide
 to change the 4-tuple over which packets from that path will be
@@ -1151,8 +1149,8 @@ If an endpoint receives a multipath-specific frame in a different packet type,
 it MUST close the connection with an error of type FRAME_ENCODING_ERROR.
 
 All multipath-specific frames relate to a Path Identifier of Destination Connection
-ID. If an endpoint receives a Path Identifier greater than any previously 
-sent to the peer, it MUST treat this as a connection error of type MP_PROTOCOL_VIOLATION. 
+ID. If an endpoint receives a Path Identifier greater than any previously
+sent to the peer, it MUST treat this as a connection error of type MP_PROTOCOL_VIOLATION.
 If an endpoint receives a multipath-specific frame
 with a Path Identifier that it cannot process
 anymore (e.g., because the path might have been abandoned), it
@@ -1188,8 +1186,8 @@ Compared to the ACK frame specified in {{QUIC-TRANSPORT}}, the following
 field is added.
 
 Path Identifier:
-: The path identifier pre-allocated of the Destination Connection ID. This 
-  field identifies the packet number space of the 0-RTT and 1-RTT packets 
+: The path identifier pre-allocated of the Destination Connection ID. This
+  field identifies the packet number space of the 0-RTT and 1-RTT packets
   which are acknowledged by the ACK_MP frame.
 
 ## PATH_ABANDON Frame {#path-abandon-frame}
@@ -1261,8 +1259,8 @@ Path Identifier:
   MAY be specified, even if they are not yet in use over a path.
 
 Path Status sequence number:
-: A variable-length integer specifying the sequence number assigned for 
-  this PATH_STANDBY frame. The sequence number space is shared with the 
+: A variable-length integer specifying the sequence number assigned for
+  this PATH_STANDBY frame. The sequence number space is shared with the
   PATH_AVAILABLE frame and the sequence
   number MUST be monotonically increasing generated by the sender of
   the PATH_STANDBY frame in the same connection. The receiver of
@@ -1307,11 +1305,11 @@ PATH_AVAILABLE frames contain the following fields:
 Path Identifier:
 : The Path Identifier of the Destination Connection ID used by the
   receiver of this frame to send packets over the path the status update
-  corresponds to. 
+  corresponds to.
 
 Path Status sequence number:
 : A variable-length integer specifying
-  the sequence number assigned for this PATH_AVAILABLE frame. 
+  the sequence number assigned for this PATH_AVAILABLE frame.
   The sequence number space is shared with the PATH_STANDBY frame and the sequence
   number MUST be monotonically increasing generated by the sender of
   the PATH_AVAILABLE frame in the same connection. The receiver of
@@ -1336,9 +1334,9 @@ before or during path initiation.
 
 ## MP_NEW_CONNECTION_ID frames {#mp-new-conn-id-frame}
 
-An endpoint sends a MP_NEW_CONNECTION_ID frame (type=0x15228c09) instead of 
-the NEW_CONNECTION_ID frame to provide its peer with alternative connection IDs 
-that can be used to break linkability when migrating connections; 
+An endpoint sends a MP_NEW_CONNECTION_ID frame (type=0x15228c09) instead of
+the NEW_CONNECTION_ID frame to provide its peer with alternative connection IDs
+that can be used to break linkability when migrating connections;
 see {{Section 19.15 of QUIC-TRANSPORT}}.
 
 MP_NEW_CONNECTION_ID frames are formatted as shown in {{fig-mp-connection-id-frame-format}}.
@@ -1363,37 +1361,37 @@ Path Identifier:
 means the current Connection ID can only be used on the corresponding path.
 
 Sequence Number:
-The sequence number assigned to the connection ID by the sender on the path 
-specified by Path Identifier, encoded as a variable-length integer. 
-Note that the sequence number is allocated dependently on each path, 
-which means different Connection IDs on different paths may have the same 
+The sequence number assigned to the connection ID by the sender on the path
+specified by Path Identifier, encoded as a variable-length integer.
+Note that the sequence number is allocated dependently on each path,
+which means different Connection IDs on different paths may have the same
 sequence number value.
 
 Retire Prior To:
-: A variable-length integer indicating which connection IDs should be retired 
+: A variable-length integer indicating which connection IDs should be retired
 on the path specified by Path Identifier; see {{consume-retire-cid}}.
 
 Length:
-An 8-bit unsigned integer containing the length of the connection ID. Values 
-less than 1 and greater than 20 are invalid and MUST be treated as a connection 
+An 8-bit unsigned integer containing the length of the connection ID. Values
+less than 1 and greater than 20 are invalid and MUST be treated as a connection
 error of type FRAME_ENCODING_ERROR.
 
 Connection ID:
 A connection ID of the specified length.
 
 Stateless Reset Token:
-A 128-bit value that will be used for a stateless reset when the associated 
+A 128-bit value that will be used for a stateless reset when the associated
 connection ID is used.
 
-The Sequence Number field and Retire Prior To field is allocated 
-for each path independently. The Retire Prior To field indicates which connection IDs 
+The Sequence Number field and Retire Prior To field is allocated
+for each path independently. The Retire Prior To field indicates which connection IDs
 should be retired on the corresponding path of Path Identifier.
 
-The Retire Prior To field applies to connection IDs established during 
-connection setup if the Path Identifier is 0 indicating the initial path; see {{consume-retire-cid}}. 
-The value in the Retire Prior To field MUST be less than or equal to the value 
-in the Sequence Number field. Receiving a value in the Retire Prior To field 
-that is greater than that in the Sequence Number field MUST be treated as 
+The Retire Prior To field applies to connection IDs established during
+connection setup if the Path Identifier is 0 indicating the initial path; see {{consume-retire-cid}}.
+The value in the Retire Prior To field MUST be less than or equal to the value
+in the Sequence Number field. Receiving a value in the Retire Prior To field
+that is greater than that in the Sequence Number field MUST be treated as
 a connection error of type FRAME_ENCODING_ERROR.
 
 Length, Connection ID, Stateless Reset Token fields have exactly the same
@@ -1401,18 +1399,18 @@ definition in NEW_CONNECTION_ID frame {{Section 19.15 of QUIC-TRANSPORT}}.
 
 Note that Connection IDs issued in NEW_CONNECTION_ID frames MUST be treated as
 their Path Identifier is 0. Also the retire prior to field of NEW_CONNECTION_ID frames
-just effect the Connection IDs of initial path with path ID 0. This machanism 
-is compatible with {{QUIC-Transport}}.
+just effect the Connection IDs of initial path with path ID 0. This machanism
+is compatible with {{QUIC-TRANSPORT}}.
 
 
 ## MP_RETIRE_CONNECTION_ID frames {#mp-retire-conn-id-frame}
 
-An endpoint sends a MP_RETIRE_CONNECTION_ID frame (type=0x15228c0a) instead of 
-RETIRE_CONNECTION_ID frame to indicate that it will no longer use a connection ID 
-that was issued by its peer. This includes the connection ID provided during the handshake. 
-Sending a MP_RETIRE_CONNECTION_ID frame also serves as a request to the peer 
-to send additional connection IDs for future use, unless the path specified 
-by Path Identifier has been abandoned. New connection IDs can be 
+An endpoint sends a MP_RETIRE_CONNECTION_ID frame (type=0x15228c0a) instead of
+RETIRE_CONNECTION_ID frame to indicate that it will no longer use a connection ID
+that was issued by its peer. This includes the connection ID provided during the handshake.
+Sending a MP_RETIRE_CONNECTION_ID frame also serves as a request to the peer
+to send additional connection IDs for future use, unless the path specified
+by Path Identifier has been abandoned. New connection IDs can be
 delivered to a peer using the MP_NEW_CONNECTION_ID frame ({{mp-new-conn-id-frame}}).
 
 Retiring a connection ID invalidates the stateless reset token associated with that connection ID.
@@ -1433,14 +1431,14 @@ Path Identifier:
 means the current Connection ID can only be used on the corresponding path.
 
 Sequence Number:
-The sequence number assigned to the connection ID by the sender on the path 
-specified by Path Identifier, encoded as a variable-length integer. 
+The sequence number assigned to the connection ID by the sender on the path
+specified by Path Identifier, encoded as a variable-length integer.
 
 
 ## MAX_PATHS frames {#max-paths-frame}
 
-A MAX_PATHS frame (type=0x15228c0b) informs the peer of the cumulative number of paths 
-it is permitted to open. 
+A MAX_PATHS frame (type=0x15228c0b) informs the peer of the cumulative number of paths
+it is permitted to open.
 
 MAX_PATHS frames are formatted as shown in {{fig-max-paths-frame-format}}.
 
@@ -1455,18 +1453,18 @@ MAX_PATHS Frame {
 MAX_PATHS frames contain the following field:
 
 Maximum Path Identifier:
-: A count of the cumulative number of path that can be opened 
-over the lifetime of the connection. This value cannot exceed 2^32-1, as it is not 
-possible to encode Path IDs larger than 2^32-1. Receipt of a frame that permits 
-opening of a path with Path Identifier larger than this limit MUST be treated 
+: A count of the cumulative number of path that can be opened
+over the lifetime of the connection. This value cannot exceed 2^32-1, as it is not
+possible to encode Path IDs larger than 2^32-1. Receipt of a frame that permits
+opening of a path with Path Identifier larger than this limit MUST be treated
 as a connection error of type FRAME_ENCODING_ERROR.
 
-Loss or reordering can cause an endpoint to receive a MAX_PATHS frame with 
-a lower path limit than was previously received. MAX_PATHS frames that 
+Loss or reordering can cause an endpoint to receive a MAX_PATHS frame with
+a lower path limit than was previously received. MAX_PATHS frames that
 do not increase the path limit MUST be ignored.
 
 An endpoint MUST NOT initiate a path with a path ID higher than the Maximum Paths value.
-An endpoint MUST terminate the a connection with an error of type MP_PROTOCOL_VIOLATION if a peer opens more paths than was permitted. 
+An endpoint MUST terminate the a connection with an error of type MP_PROTOCOL_VIOLATION if a peer opens more paths than was permitted.
 
 
 # Error Codes {#error-codes}


### PR DESCRIPTION
Also seems like you had a load of trailing whitespace that would hurt the linter's feelings.