### PR TITLE
Use even numbers for path ID

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -336,7 +336,7 @@ that future extensions will lift the requirement in {{path-initiation}} that
 paths are only initiated by clients. In that case, to avoid collisions,
 we will need separate path IDs number spaces for client-initiated and
 server-initiated paths, such as using even numbered path IDs for client-initiated paths
-and odd numbered path IDs for server initiated paths.
+and odd numbered path IDs for server-initiated paths.
 
 
 # Path Setup and Removal {#setup}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1402,7 +1402,7 @@ last MAX_PATHS frame received from the peer, or the value received
 from the peer in
 the initial_max_paths transport parameters if no MAX_PATHS frames have
 been received. MP_NEW_CONNECTION_ID received as
-with a laue larger than authorized MUST be treated as
+with Path ID value larger than authorized MUST be treated as
 a connection error of type MP_PROTOCOL_VIOLATION.
 
 The Sequence Number field and Retire Prior To field is allocated

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -335,7 +335,7 @@ This specification requires path IDs to be even numbers. We anticipate
 that future extensions will lift the requirement in {{path-initiation}} that
 paths are only initiated by clients. In that case, to avoid collisions,
 we will need separate path IDs number spaces for client-initiated and
-server initiated spaces, such as using even numbered path IDs for client initiated paths
+server-initiated paths, such as using even numbered path IDs for client-initiated paths
 and odd numbered path IDs for server initiated paths.
 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1484,7 +1484,7 @@ For example, if an endpoint received a Maximum Paths value of 2,
 it may send MP_NEW_CONNECTION_ID with Path ID 0 and 2, but not higher.
 
 The Maximum Paths value cannot exceed 2^31-1, as it is not
-possible to encode Path IDs larger than 2^32-2. Receipt of a 
+possible to encode Path IDs larger than 2^32-2. Receipt of a
 Path Identifier larger than this limit MUST be treated
 as a connection error of type FRAME_ENCODING_ERROR.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1480,8 +1480,8 @@ over the lifetime of the connection.
 
 The endpoint receiving this frame MAY send MP_NEW_CONNECTION_ID frames
 with Path IDs strictly lower than twice the Maximum Paths.
-For example, if an endpoint received a Maximum Paths value of 2,
-it may send MP_NEW_CONNECTION_ID with Path ID 0 and 2, but not higher.
+For example, if an endpoint received a Maximum Paths value of 3,
+it may send MP_NEW_CONNECTION_ID with Path ID 0, 2 and 4, but not higher.
 
 The Maximum Paths value cannot exceed 2^31-1, as it is not
 possible to encode Path IDs larger than 2^32-2. Receipt of a

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1401,7 +1401,7 @@ The Path Identifier MUST NOT be larger than the value authorized in the
 last MAX_PATHS frame received from the peer, or the value received
 from the peer in
 the initial_max_paths transport parameters if no MAX_PATHS frames have
-been received. MP_NEW_CONNECTION_ID received as
+been received. MP_NEW_CONNECTION_ID received
 with Path ID value larger than authorized MUST be treated as
 a connection error of type MP_PROTOCOL_VIOLATION.
 


### PR DESCRIPTION
This PR specifies using even number path identifiers. It anticipates the possibility of using the odd numbered identifiers for server-initiated paths, but does not specify how to do that. As a result, it is much simpler than PR #329.

Close #328