### PR TITLE
Rewrite outdated examples in Section 6

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -829,8 +829,8 @@ Path ID 1), and server provides two connection IDs
 Before the client opens a new path by sending a packet on that path
 with a PATH_CHALLENGE frame, it has to check whether there is
 an unused connection IDs for the same unused Path ID available for each side.
-Endpoints SHOULD consume the smallest unused Path ID available
-when creating the new path as specified in {{consume-retire-cid}}.
+In this example the Path ID 1 is used which is the smallest unused Path ID available
+as recommended in {{consume-retire-cid}}.
 Respectively, the client chooses the connection ID S1
 as the Destination Connection ID of the new path.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -856,9 +856,6 @@ Client                                                      Server
 ~~~
 {: #fig-example-path-close1 title="Example of closing a path."}
 
-Note that if endpoints have other available paths, endpoints are also
-able to send the PATH_ABANDON frame on another available path. This mechanism
-can be used for closing blackhole paths.
 
 
 # Implementation Considerations

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -840,14 +840,9 @@ as the Destination Connection ID of the new path.
 {{fig-example-path-close1}} illustrates an example of path closure.
 
 In this example, the client wants to close the path with Path ID 1.
-It sends the PATH_ABANDON frame to terminate the path. After received
-the PATH_ABANDON frame containing Path ID 1, the server decide to close
-the path with sending PATH_ABANDON frame either. During this time,
-if endpoints still receive inflight packets except the acknowledgements,
-endpoints only sends PATH_ABANDON frame as reply or choose to ignore the inflight packets.
-After a short period of time (3 PTOs as specified in {#path-close}),
-both endpoints retire and free all the resources associated with
-the closed Path ID, and the closed Path ID MUST NOT be reused in the future.
+It sends the PATH_ABANDON frame to terminate the path. After receiving
+the PATH_ABANDON frame with Path ID 1, the server also send a 
+PATH_ABANDON frame with Path ID 1. 
 
 ~~~
 Client                                                      Server

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -853,8 +853,6 @@ Client                                                      Server
                     <-1-RTT[Y]: DCID=C1 PATH_ABANDON[Path ID=1],
                                            ACK_MP[PATH ID=1, PN=X]
 1-RTT[U]: DCID=S1 ACK_MP[Path ID=1, PN=Y] ->
-(After 3 PTOs, client retires the corresponding CID)
-              (After 3 PTOs, server retires the corresponding CID)
 ~~~
 {: #fig-example-path-close1 title="Example of closing a path."}
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -795,9 +795,10 @@ should not cause linkability issue.
 {{fig-example-new-path}} illustrates an example of new path establishment
 using multiple packet number spaces.
 
-In the handshake negotiation of the example flow, Client and Server
-successfully negotiate the initial_max_path_id value as 2, which means
-both endpoints could use Path ID 0, 1, and 2.
+In this example it is assume that both endpoint have
+indicated a initial_max_path_id value as at least 2, which means
+both endpoints can use Path IDs 0, 1, and 2. Note that
+Path ID 0 is already used for the initial path.
 
 ~~~
    Client                                                  Server

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -857,7 +857,6 @@ Client                                                      Server
 {: #fig-example-path-close1 title="Example of closing a path."}
 
 
-
 # Implementation Considerations
 
 ## Number Spaces

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -841,8 +841,8 @@ as the Destination Connection ID of the new path.
 
 In this example, the client wants to close the path with Path ID 1.
 It sends the PATH_ABANDON frame to terminate the path. After receiving
-the PATH_ABANDON frame with Path ID 1, the server also send a 
-PATH_ABANDON frame with Path ID 1. 
+the PATH_ABANDON frame with Path ID 1, the server also send a
+PATH_ABANDON frame with Path ID 1.
 
 ~~~
 Client                                                      Server

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -852,9 +852,11 @@ Client                                                      Server
                            (server tells client to abandon a path)
                     <-1-RTT[Y]: DCID=C1 PATH_ABANDON[Path ID=1],
                                            ACK_MP[PATH ID=1, PN=X]
-1-RTT[U]: DCID=S1 ACK_MP[Path ID=1, PN=Y] ->
+1-RTT[U]: DCID=S2 ACK_MP[Path ID=1, PN=Y] ->
 ~~~
 {: #fig-example-path-close1 title="Example of closing a path."}
+
+Note that the last acknowledgement needs to be send on a different path. This examples assumes another path which uses connection ID S2 exists.
 
 
 # Implementation Considerations

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -795,8 +795,8 @@ should not cause linkability issue.
 {{fig-example-new-path}} illustrates an example of new path establishment
 using multiple packet number spaces.
 
-In this example it is assume that both endpoint have
-indicated a initial_max_path_id value as at least 2, which means
+In this example it is assumed that both endpoint have
+indicated an initial_max_path_id value of at least 2, which means
 both endpoints can use Path IDs 0, 1, and 2. Note that
 Path ID 0 is already used for the initial path.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -852,7 +852,7 @@ the closed Path ID, and the closed Path ID MUST NOT be reused in the future.
 ~~~
 Client                                                      Server
 
-(client tells server to abandon a path with Path ID=1)
+(client tells server to abandon a path with Path ID 1)
 1-RTT[X]: DCID=S1 PATH_ABANDON[Path ID=1]->
                            (server tells client to abandon a path)
                     <-1-RTT[Y]: DCID=C1 PATH_ABANDON[Path ID=1],


### PR DESCRIPTION
According to PR #377 and PR #375, the examples in [Section 6](https://datatracker.ietf.org/doc/html/draft-ietf-quic-multipath-08#section-6) is outdated. Try to update the figures and keep examples compatible.