### PR TITLE
[=] Cleanup MAX_PATHS

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1321,7 +1321,7 @@ MAX_PATHS frames are formatted as shown in {{fig-max-paths-frame-format}}.
 ~~~
 MAX_PATHS Frame {
   Type (i) = 0x15228c0b,
-  Maximum Paths (i),
+  Maximum Path Identifier (i),
 }
 ~~~
 {: #fig-max-paths-frame-format title="MAX_PATHS Frame Format"}
@@ -1332,18 +1332,19 @@ Maximum Path Identifier:
 : A count of the cumulative number of paths that can be opened
   over the lifetime of the connection. This value MUST NOT exceed 2^32-1, as
   Path IDs are defined with a maximum value 2^32-1 as the 32 bits of the Path ID are used
-  to calculate the nonce (see Section {{multipath-aead}}).
+  to calculate the nonce (see {{multipath-aead}}).
   The Maximum Paths value MUST NOT be lower than the value
   advertised in the initial_max_paths transport parameter. Receipt
-  of an invalid Maximum Paths value MUST be treated as a
+  of an invalid Maximum Path Identifier value MUST be treated as a
   connection error of type MP_PROTOCOL_VIOLATION.
 
 Loss or reordering can cause an endpoint to receive a MAX_PATHS frame with
-a smaller Maximum Paths value than was previously received. MAX_PATHS frames that
-do not increase the path limit MUST be ignored.
+a smaller Maximum Path Identifier value than was previously received.
+MAX_PATHS frames that do not increase the path limit MUST be ignored.
 
 
 # Error Codes {#error-codes}
+
 Multipath QUIC transport error codes are 62-bit unsigned integers
 following {{QUIC-TRANSPORT}}.
 


### PR DESCRIPTION
This is the original proposal of Martin's PR: 

> There was a naming inconsistency here.
> 
> I went with one direction, which I think works best as it has a direct relation to the path identifier.  MAX_STREAMS uses a count because of the way in which streams are allocated odd/even.  That awkwardness we have for streams isn't necessary here.

This part is merged into the current branch to make the modification of transport parameter and frame have the same semantics and easier to review.