### PR TITLE
Editorial minor change to not repeat RFC9000 behaviour

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -664,7 +664,7 @@ will not be used anymore. In response, if the path is still active, the peer
 SHOULD provide new connection IDs using MP_NEW_CONNECTION_ID frames.
 
 Retirement of connection IDs will not retire the Path ID
-that correspones to the connection ID or any other path ressources
+that corresponds to the connection ID or any other path ressources
 as the packet number space is associated with a path.
 
 The peer that sends the MP_RETIRE_CONNECTION_ID frame can keep sending data

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -664,9 +664,8 @@ will not be used anymore. In response, if the path is still active, the peer
 SHOULD provide new connection IDs using MP_NEW_CONNECTION_ID frames.
 
 Retirement of connection IDs will not retire the Path ID
-that correspones to the connection ID.
-The list of received packets used to send acknowledgements also remains
-unaffected as the packet number space is associated with a path.
+that correspones to the connection ID or any other path ressources
+as the packet number space is associated with a path.
 
 The peer that sends the MP_RETIRE_CONNECTION_ID frame can keep sending data
 on the path that the retired connection ID was used on but has


### PR DESCRIPTION
fixes #339 

This proposed editorial edit still mentions that packet numbers are per path. However, alternative we could also remove this second sentence entirely as it is normal RFC9000 behavior that retirement of a CID will not remove any path ressources.