### PR TITLE
Multiple paths may use the same 4 tuple.

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -964,8 +964,8 @@ at any time during the connection. As such a sole change of the Connection
 ID without any change in the address does not indicate a path change and
 the endpoint can keep the same congestion control and RTT measurement state.
 
-While endpoints send a packet on a specific path with the associated
-4-tuple, networks events such as NAT rebinding may make the packet's receiver
+While endpoints assign a connection ID to a specific sending 4-tuple,
+networks events such as NAT rebinding may make the packet's receiver
 observe a different 4-tuple. Servers observing a 4-tuple change will
 perform path validation (see {{Section 9 of QUIC-TRANSPORT}}).
 If path validation process succeeds, the endpoints set

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -183,9 +183,6 @@ when a packet arrives with a connection ID
 pointing to an existing path ID, but the connection ID and/or the
 4-tuple are different from the value associated with that path
 (see {{migration}}).
-  * NAT rebinding events are detected when packets
-are received from a different 4-tuple than the one previously associated
-with the path ID.
   * Paths can be closed at any time, as specified in {{path-close}}.
   * It is not impossible to create multiple paths sharing the same 4-tuple.
 Each of these paths can be closed at any time, like any other path.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -184,7 +184,7 @@ pointing to an existing path ID, but the connection ID and/or the
 4-tuple are different from the value associated with that path
 (see {{migration}}).
   * Paths can be closed at any time, as specified in {{path-close}}.
-  * It is not impossible to create multiple paths sharing the same 4-tuple.
+  * It is possible to create multiple paths sharing the same 4-tuple.
 Each of these paths can be closed at any time, like any other path.
 
 Further the design of this extension introduces an explicit path identifier

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -640,7 +640,7 @@ for a given Path ID to its peer. Endpoints SHOULD NOT introduce discontinuity
 in the issuing of Path IDs through their connection ID advertisements as path initiation
 requires available connection IDs for the same Path ID on both sides. For instance,
 if the maximum Path ID limit is 2 and the endpoint wants to provide connection IDs
-for only one Path ID inside range (1, 2), it should select Path ID 1 (and not Path
+for only one Path ID inside range \[1, 2\], it should select Path ID 1 (and not Path
 ID 2). Similarly, endpoints SHOULD consume Path IDs in a continuous way, i.e., when
 creating paths. However, endpoints cannot expect to receive new connection IDs
 or path initiation attempts with in order use of Path IDs


### PR DESCRIPTION
This is a simple PR designed to fix issue #378. It is mostly editorial, simply stating that multiple path sharing the same 4-tuple is just fine, and checking the draft to make sure we never say that a path is defined by a 4-tuple.