### PR TITLE
Add MAX_PATH_ID_BLOCKED frame and related texts

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -667,7 +667,7 @@ in Section {{frames}}.
 When an endpoint finds it has not enough available unused path identifiers,
 it SHOULD either send a MAX_PATH_ID frame to increase the active path limit
 (when limited by the sender) or a PATHS_BLOCKED frame
-(see Section {{max-paths-blocked-frame}}) to inform the peer that a new path
+(see Section {{paths-blocked-frame}}) to inform the peer that a new path
 identifier was needed but the current limit set by the peer prevented the
 creation of the new path.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -666,7 +666,7 @@ Receipt of a frame with a greater Path ID is a connection error as specified
 in Section {{frames}}.
 When an endpoint finds it has not enough available unused path identifiers,
 it SHOULD either send a MAX_PATH_ID frame to increase the active path limit
-(when limited by the sender) or a MAX_PATH_ID_BLOCKED frame
+(when limited by the sender) or a PATHS_BLOCKED frame
 (see Section {{max-paths-blocked-frame}}) to inform the peer that a new path
 identifier was needed but the current limit set by the peer prevented the
 creation of the new path.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -654,11 +654,11 @@ as corresponding to Path ID 0.
 
 Endpoints MUST NOT issue new connection IDs with Path IDs greater than
 the Maximum Path Identifier field in MAX_PATH_ID frames (see Section {{max-paths-frame}}).
-When an endpoint finds it has not enough available unused path identifiers, 
-it SHOULD either send a MAX_PATH_ID frame to increase the active path limit 
-(when limited by the sender) or a MAX_PATH_ID_BLOCKED frame 
-(see Section {{max-paths-blocked-frame}}) to inform the peer that a new path 
-identifier was needed but the current limit set by the peer prevented the 
+When an endpoint finds it has not enough available unused path identifiers,
+it SHOULD either send a MAX_PATH_ID frame to increase the active path limit
+(when limited by the sender) or a MAX_PATH_ID_BLOCKED frame
+(see Section {{max-paths-blocked-frame}}) to inform the peer that a new path
+identifier was needed but the current limit set by the peer prevented the
 creation of the new path.
 
 If the client has consumed all the allocated connection IDs for a path, it is supposed to retire
@@ -1251,9 +1251,9 @@ also needs to be considered in the context of the Path Identifier field.
 A MAX_PATH_ID frame (type=0x15228c0c) informs the peer of the maximum path identifier
 it is permitted to use.
 
-When there are not enough unused path identifiers, endpoints SHOULD either send a 
-MAX_PATH_ID frame to increase the active path limit (when limited by the sender) 
-or a MAX_PATH_ID_BLOCKED frame to inform the peer that a new path identifier was needed 
+When there are not enough unused path identifiers, endpoints SHOULD either send a
+MAX_PATH_ID frame to increase the active path limit (when limited by the sender)
+or a MAX_PATH_ID_BLOCKED frame to inform the peer that a new path identifier was needed
 but the limit of active paths set by the peer has been reached.
 
 MAX_PATH_ID frames are formatted as shown in {{fig-max-paths-frame-format}}.
@@ -1283,8 +1283,8 @@ MAX_PATH_ID frames that do not increase the path limit MUST be ignored.
 
 ## MAX_PATH_ID_BLOCKED frames {#max-paths-blocked-frame}
 
-A sender SHOULD send a MAX_PATH_ID_BLOCKED frame (type=0x15228c0d) when 
-it wishes to open a path but is unable to do so due to the maximum path identifier 
+A sender SHOULD send a MAX_PATH_ID_BLOCKED frame (type=0x15228c0d) when
+it wishes to open a path but is unable to do so due to the maximum path identifier
 limit set by its peer;
 
 MAX_PATH_ID_BLOCKED frames are formatted as shown in {{fig-max-paths-blocked-frame-format}}.
@@ -1300,10 +1300,10 @@ MAX_PATH_ID_BLOCKED Frame {
 MAX_PATH_ID frames contain the following field:
 
 Maximum Path Identifier:
-A variable-length integer indicating the maximum number of path identifiers 
-allowed at the time the frame was sent. This value MUST NOT exceed 2^32-1 
-and MUST NOT be lower than the value advertised in the initial_max_path_id 
-transport parameter. Receipt of an invalid Maximum Path Identifier value MUST 
+A variable-length integer indicating the maximum number of path identifiers
+allowed at the time the frame was sent. This value MUST NOT exceed 2^32-1
+and MUST NOT be lower than the value advertised in the initial_max_path_id
+transport parameter. Receipt of an invalid Maximum Path Identifier value MUST
 be treated as a connection error of type MP_PROTOCOL_VIOLATION.
 
 # Error Codes {#error-codes}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1354,7 +1354,7 @@ TBD-04 (experiments use 0x15228c08)                  | PATH_AVAILABLE      | {{p
 TBD-05 (experiments use 0x15228c09)                  | MP_NEW_CONNECTION_ID   | {{mp-new-conn-id-frame}}
 TBD-06 (experiments use 0x15228c0a)                  | MP_RETIRE_CONNECTION_ID| {{mp-retire-conn-id-frame}}
 TBD-07 (experiments use 0x15228c0c)                  | MAX_PATH_ID            | {{max-paths-frame}}
-TBD-08 (experiments use 0x15228c0d)                  | MAX_PATH_ID_BLOCKED    | {{max-paths-blocked-frame}}
+TBD-08 (experiments use 0x15228c0d)                  | PATHS_BLOCKED    | {{max-paths-blocked-frame}}
 {: #frame-types title="Addition to QUIC Frame Types Entries"}
 
 The following transport error code defined in {{tab-error-code}} should

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1295,7 +1295,7 @@ limit set by its peer;
 PATHS_BLOCKED frames are formatted as shown in {{fig-max-paths-blocked-frame-format}}.
 
 ~~~
-MAX_PATH_ID_BLOCKED Frame {
+PATHS_BLOCKED Frame {
   Type (i) = 0x15228c0d,
   Maximum Path Identifier (i),
 }

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1288,7 +1288,7 @@ MAX_PATH_ID frames that do not increase the path limit MUST be ignored.
 
 ## PATHS_BLOCKED frames {#paths-blocked-frame}
 
-A sender SHOULD send a MAX_PATH_ID_BLOCKED frame (type=0x15228c0d) when
+A sender SHOULD send a PATHS_BLOCKED frame (type=0x15228c0d) when
 it wishes to open a path but is unable to do so due to the maximum path identifier
 limit set by its peer;
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -357,8 +357,9 @@ This proposal adds five multipath control frames for path management:
 - PATH_STANDBY and PATH_AVAILABLE frames to express a preference
 in path usage (see {{path-standby-frame}} and {{path-available-frame}}), and
 - MAX_PATH_ID frame (see {{max-paths-frame}}) for increasing the limit of
-active paths, while PATHS_BLOCKED frame (see {{paths-blocked-frame}})
-indicates that the limit of active paths set by the peer has been reached.
+active paths, and PATHS_BLOCKED frame (see {{paths-blocked-frame}})
+to notify the peer of being blocked to open new paths as
+the limit of active paths set by the peer has been reached.
 
 All new frames are sent in 1-RTT packets {{QUIC-TRANSPORT}}.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1292,7 +1292,7 @@ A sender SHOULD send a PATHS_BLOCKED frame (type=0x15228c0d) when
 it wishes to open a path but is unable to do so due to the maximum path identifier
 limit set by its peer;
 
-MAX_PATH_ID_BLOCKED frames are formatted as shown in {{fig-max-paths-blocked-frame-format}}.
+PATHS_BLOCKED frames are formatted as shown in {{fig-max-paths-blocked-frame-format}}.
 
 ~~~
 MAX_PATH_ID_BLOCKED Frame {

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1306,11 +1306,11 @@ PATHS_BLOCKED Frame {
 PATHS_BLOCKED frames contain the following field:
 
 Maximum Path Identifier:
-: A variable-length integer indicating the maximum number of path identifiers
-  allowed at the time the frame was sent. This value MUST NOT exceed 2^32-1
-  and MUST NOT be lower than the value advertised in the initial_max_path_id
-  transport parameter. Receipt of an invalid Maximum Path Identifier value MUST
-  be treated as a connection error of type MP_PROTOCOL_VIOLATION.
+: A variable-length integer indicating the maximum path identifier that was
+  allowed at the time the frame was sent. If the received value is lower than
+  the currently allowed maximum value, this frame can be ignored.
+  Receipt of a value that is higher than the local maximum value MUST
+  be treated as a connection error of type PROTOCOL_VIOLATION.
 
 # Error Codes {#error-codes}
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1300,11 +1300,11 @@ MAX_PATH_ID_BLOCKED Frame {
 MAX_PATH_ID frames contain the following field:
 
 Maximum Path Identifier:
-A variable-length integer indicating the maximum number of path identifiers
-allowed at the time the frame was sent. This value MUST NOT exceed 2^32-1
-and MUST NOT be lower than the value advertised in the initial_max_path_id
-transport parameter. Receipt of an invalid Maximum Path Identifier value MUST
-be treated as a connection error of type MP_PROTOCOL_VIOLATION.
+: A variable-length integer indicating the maximum number of path identifiers
+  allowed at the time the frame was sent. This value MUST NOT exceed 2^32-1
+  and MUST NOT be lower than the value advertised in the initial_max_path_id
+  transport parameter. Receipt of an invalid Maximum Path Identifier value MUST
+  be treated as a connection error of type MP_PROTOCOL_VIOLATION.
 
 # Error Codes {#error-codes}
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -357,7 +357,7 @@ This proposal adds five multipath control frames for path management:
 - PATH_STANDBY and PATH_AVAILABLE frames to express a preference
 in path usage (see {{path-standby-frame}} and {{path-available-frame}}), and
 - MAX_PATH_ID frame (see {{max-paths-frame}}) for increasing the limit of
-active paths, while PATHS_BLOCKED frame (see {{max-paths-blocked-frame}})
+active paths, while PATHS_BLOCKED frame (see {{paths-blocked-frame}})
 indicates that the limit of active paths set by the peer has been reached.
 
 All new frames are sent in 1-RTT packets {{QUIC-TRANSPORT}}.
@@ -1292,7 +1292,7 @@ A sender SHOULD send a PATHS_BLOCKED frame (type=0x15228c0d) when
 it wishes to open a path but is unable to do so due to the maximum path identifier
 limit set by its peer;
 
-PATHS_BLOCKED frames are formatted as shown in {{fig-max-paths-blocked-frame-format}}.
+PATHS_BLOCKED frames are formatted as shown in {{fig-paths-blocked-frame-format}}.
 
 ~~~
 PATHS_BLOCKED Frame {
@@ -1300,7 +1300,7 @@ PATHS_BLOCKED Frame {
   Maximum Path Identifier (i),
 }
 ~~~
-{: #fig-max-paths-blocked-frame-format title="MAX_PATH_ID_BLOCKED Frame Format"}
+{: #fig-paths-blocked-frame-format title="MAX_PATH_ID_BLOCKED Frame Format"}
 
 PATHS_BLOCKED frames contain the following field:
 
@@ -1354,7 +1354,7 @@ TBD-04 (experiments use 0x15228c08)                  | PATH_AVAILABLE      | {{p
 TBD-05 (experiments use 0x15228c09)                  | MP_NEW_CONNECTION_ID   | {{mp-new-conn-id-frame}}
 TBD-06 (experiments use 0x15228c0a)                  | MP_RETIRE_CONNECTION_ID| {{mp-retire-conn-id-frame}}
 TBD-07 (experiments use 0x15228c0c)                  | MAX_PATH_ID            | {{max-paths-frame}}
-TBD-08 (experiments use 0x15228c0d)                  | PATHS_BLOCKED    | {{max-paths-blocked-frame}}
+TBD-08 (experiments use 0x15228c0d)                  | PATHS_BLOCKED    | {{paths-blocked-frame}}
 {: #frame-types title="Addition to QUIC Frame Types Entries"}
 
 The following transport error code defined in {{tab-error-code}} should

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -357,7 +357,7 @@ This proposal adds five multipath control frames for path management:
 - PATH_STANDBY and PATH_AVAILABLE frames to express a preference
 in path usage (see {{path-standby-frame}} and {{path-available-frame}}), and
 - MAX_PATH_ID frame (see {{max-paths-frame}}) for increasing the limit of
-active paths, while MAX_PATH_ID_BLOCKED frame (see {{max-paths-blocked-frame}})
+active paths, while PATHS_BLOCKED frame (see {{max-paths-blocked-frame}})
 indicates that the limit of active paths set by the peer has been reached.
 
 All new frames are sent in 1-RTT packets {{QUIC-TRANSPORT}}.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1302,7 +1302,7 @@ MAX_PATH_ID_BLOCKED Frame {
 ~~~
 {: #fig-max-paths-blocked-frame-format title="MAX_PATH_ID_BLOCKED Frame Format"}
 
-MAX_PATH_ID frames contain the following field:
+PATHS_BLOCKED frames contain the following field:
 
 Maximum Path Identifier:
 : A variable-length integer indicating the maximum number of path identifiers

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1286,7 +1286,7 @@ Loss or reordering can cause an endpoint to receive a MAX_PATH_ID frame with
 a smaller Maximum Path Identifier value than was previously received.
 MAX_PATH_ID frames that do not increase the path limit MUST be ignored.
 
-## MAX_PATH_ID_BLOCKED frames {#max-paths-blocked-frame}
+## PATHS_BLOCKED frames {#paths-blocked-frame}
 
 A sender SHOULD send a MAX_PATH_ID_BLOCKED frame (type=0x15228c0d) when
 it wishes to open a path but is unable to do so due to the maximum path identifier

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1350,7 +1350,6 @@ TBD-05 (experiments use 0x15228c09)                  | MP_NEW_CONNECTION_ID   | 
 TBD-06 (experiments use 0x15228c0a)                  | MP_RETIRE_CONNECTION_ID| {{mp-retire-conn-id-frame}}
 TBD-07 (experiments use 0x15228c0c)                  | MAX_PATH_ID            | {{max-paths-frame}}
 TBD-08 (experiments use 0x15228c0d)                  | MAX_PATH_ID_BLOCKED    | {{max-paths-blocked-frame}}
-
 {: #frame-types title="Addition to QUIC Frame Types Entries"}
 
 The following transport error code defined in {{tab-error-code}} should


### PR DESCRIPTION
This is an attempt to fix issue #342. I have added the MAX_PATH_ID_BLOCKED frame and related texts. Note that the same Path ID is used in both directions to address a path so the path identifier can be either limited by the sender or its peer. We should treat the two scenario differently and MAX_PATH_ID_BLOCKED should be used when the limit is set by the peer.