### PR TITLE
Do not delete both duplicate paths

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -620,6 +620,23 @@ to abandon a path for any reason, for example, removing a hole from
 the sequence of Path IDs in use. This is not an error. The endpoint that
 receive such a PATH_ABANDON frame must treat it as specified in {{path-close}}.
 
+### Closing Duplicate Paths
+
+As noted in {{basic-design-points}}, it is possible to create paths that
+refer to the same 4-tuple. There will be cases where this is intentional,
+for example if the paths use different Differentiated Service markings.
+There may also be cases where this is not intentional, maybe as a result
+of path migration. 
+
+In the non-intentional case, the endpoints
+may want to abandon one of the paths and keep the other, but
+uncoordinated Abandon from both ends of the connection may result in deleting
+two paths instead of just one. This sort of error will be avoided if only
+the client initiates the closing of duplicate paths. Applications may override
+that behavior if they can coordinate path closures at part of the
+application protocol.
+
+
 ## Refusing a New Path
 
 An endpoint may deny the establishment of a new path initiated by its

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1012,7 +1012,7 @@ multiple open paths instead.
 
 As noted in {{basic-design-points}}, it is possible to create paths that
 refer to the same 4-tuple. For example, the endpoints may want
-to create paths that use different Differentiated Service markings.
+to create paths that use different Differentiated Service {{?RFC2475}} markings.
 This could be done in conjunction with scheduling algorithms
 that match streams to paths, so that for example data frame for
 low priority streams are sent over low priority paths.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -631,9 +631,9 @@ of path migration.
 In the non-intentional case, the endpoints
 may want to abandon one of the paths and keep the other, but
 uncoordinated Abandon from both ends of the connection may result in deleting
-two paths instead of just one. This sort of error will be avoided if only
-the client initiates the closing of duplicate paths. Applications may override
-that behavior if they can coordinate path closures at part of the
+two paths instead of just one. To avoid this pitfall, only the client
+SHOULD initiate the closing of duplicate paths. Applications MAY
+override this default behavior if they can coordinate path closures at part of the
 application protocol.
 
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1025,7 +1025,7 @@ migrations. For example:
 
 Such unintentional use of the same 4-tuple on different paths ought to
 be rare. When they happen, the two paths would be redundant, and the
-endpoint will want to close one of them. 
+endpoint will want to close one of them.
 Uncoordinated Abandon from both ends of the connection may result in deleting
 two paths instead of just one. To avoid this pitfall, endpoints could
 adopt a simple coordination rule, such as only letting the client

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -626,7 +626,7 @@ As noted in {{basic-design-points}}, it is possible to create paths that
 refer to the same 4-tuple. There will be cases where this is intentional,
 for example if the paths use different Differentiated Service markings.
 There may also be cases where this is not intentional, maybe as a result
-of path migration. 
+of path migration.
 
 In the non-intentional case, the endpoints
 may want to abandon one of the paths and keep the other, but


### PR DESCRIPTION
Attempt at providing further guidance and point out risks if both endpoints attempt to close one of the duplicate paths at the same time. Also mention that there will be cases where having "duplicate" path is intentional, maybe because they have different diffserv markings.

Close #378