### PR TITLE
TRANSPORT_PARAMETER_ERROR when initial_max_path is too large

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -263,7 +263,7 @@ associated with Path IDs 0 and 1 should be issued by the peer.
 If an endpoint receives an initial_max_path_id transport parameter with value 0,
 the peer aims to  enable the multipath extension without allowing extra paths immediately.
 
-If an initial_max_path_id transport parameter value that is larger than 2^32-1
+If an initial_max_path_id transport parameter value that is higher than 2^32-1
 is received, the receiver MUST close the connection with an error of type
 TRANSPORT_PARAMETER_ERROR.
 


### PR DESCRIPTION
fixes #432 

This PR defines an error for the case when the initial_max_path value exceeds 2^32-1. As we changes the transport parameter meaning with the introduction of the explicit path ID, it was an oversight to not define an error here. Only remaining question is if TRANSPORT_PARAMETER_ERROR is the right error type?