### PR TITLE
Path abandon error code for experiments: fix in 62-bit variable int

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1422,8 +1422,8 @@ the "QUIC Protocol" heading.
 
 Value                       | Code                  | Description                   | Specification
 ----------------------------|-----------------------|-------------------------------|-------------------
-TBD-09 (experiments use 0x4150504C4142414E) | APPLICATION_ABANDON | Path abandoned at the application's request | {{error-codes}}
-TBD-10 (experiments use 0x5245534C494D4954) | RESOURCE_LIMIT_REACHED | Path abandoned due to resource limitations in the transport | {{error-codes}}
+TBD-09 (experiments use 0x004150504142414e) | APPLICATION_ABANDON | Path abandoned at the application's request | {{error-codes}}
+TBD-10 (experiments use 0x0052534C494D4954) | RESOURCE_LIMIT_REACHED | Path abandoned due to resource limitations in the transport | {{error-codes}}
 {: #tab-error-code title="Error Codes for Multipath QUIC"}
 
 


### PR DESCRIPTION
New experimental error code for path abandon error code field: 

- The hex value "0x004150504142414E" represents "APPABAN" ("APPLICATION_ABANDON" abbreviated) in UTF-8.
- The hex value "0x0052534C494D4954" represents "RSLIMIT" ("RESOURCE_LIMIT_REACHED" abbreviated) in UTF-8.