### PR TITLE
Note that issuing CIDs for all paths might be beneficial

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -658,7 +658,9 @@ with Path ID 0.
 The PATH_NEW_CONNECTION_ID frame is used to issue new connection IDs for all paths.
 In order to let the peer open new paths, it is RECOMMENDED to proactively
 issue a Connection ID for at least one unused Path ID, as long as it remains
-compatible with the peer's Maximum Path ID limit.
+compatible with the peer's Maximum Path ID limit. An endpoint MAY issue at
+least one connection ID for all path IDs up to the peer's Maximum Path ID limit
+to avoid blocking.
 
 When issuing path-specific connection IDs, an endpoint associates a sequence number
 as specified in {{Section 5.1.1 of QUIC-TRANSPORT}}. Each Path ID has its own


### PR DESCRIPTION
Based on the discussion in the interop call today, it was not clear why an endpoint would not want to issue CIDs for all path IDs up to the max path idea. If an endpoint wants to limit the number of paths, it should rather do it by limiting the max path ID explicitly. Therefore I propose this additional sentence to hind at doing this.