### PR TITLE
Text proposed to address scope/expectation

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -132,17 +132,17 @@ and the actual decision to setup or tear down paths are assumed
 to be handled by the application. But this document does not prevent future extensions from
 defining mechanisms to cope with the remaining scenarios.
 
-The framework specified in this document can be used with 
-a range of scheduling algorithms that define
+This extension can be used with 
+different scheduling algorithms that define
 how multiple simultaneously open paths are used to send packets. 
-Examples of schedulers can range from support for failover to simulatenous concurrent
+Examples of schedulers can range from support for failover to simulatenous
 use of the aggreate capacity across all active paths.
 
-The specification of scheduling for multipath in
-the general Internet is outside the scope of this document.  
-There are existing IETF specifications for path fail-over, but
-concurrently no IETF standards-track specifications for simultaneously
-using the capacity of a set of active paths. 
+This document does not specify scheduling for multipath in
+the general Internet.
+There are IETF specifications for path fail-over, but
+there are currently no IETF standards-track specifications for simultaneously
+(concurrently) using the aggreate capacity of a set of active paths. 
 
 Because the scheduling policy differs depending on application requirements,
 only some basic implementation guidance is discussed in {{impl-consideration}}.

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -132,19 +132,16 @@ and the actual decision to setup or tear down paths are assumed
 to be handled by the application. But this document does not prevent future extensions from
 defining mechanisms to cope with the remaining scenarios.
 
-This extension can be used with 
-different scheduling algorithms that define
-how multiple simultaneously open paths are used to send packets. 
-Examples of schedulers can range from support for failover to simulatenous
+Further, this document does not specify scheduling algorithms that define
+how multiple, simultaneously open paths are used to send packets.
+As these differ depending on application requirements,
+only some basic implementation guidance is discussed in {{impl-consideration}}.
+This extension can be used with different scheduling algorithms that,
+e.g., can range from support for failover to simulatenous
 use of the aggreate capacity across all active paths.
-
-This document does not specify a scheduling algorithm.
 There are IETF specifications for path fail-over, but
 there are currently no IETF standards-track specifications for simultaneously
-(concurrently) using the aggreate capacity of a set of active paths. 
-
-Because the scheduling policy differs depending on application requirements,
-only some basic implementation guidance is discussed in {{impl-consideration}}.
+(concurrently) using the aggregated capacity of a set of active paths. 
 Specifically, while failover between Wi-Fi
 and mobile networks is a well-known multipath use case,
 it only temporarily uses two paths at the same time 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -141,7 +141,7 @@ use of the aggreate capacity across all active paths.
 The specification of scheduling for multipath in
 the general Internet is outside the scope of this document.  
 There are existing IETF specifications for path fail-over, but
-concurrently no IETF standards-track specifications for simulatenously
+concurrently no IETF standards-track specifications for simultaneously
 using the capacity of a set of active paths. 
 
 Because the scheduling policy differs depending on application requirements,

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -132,21 +132,28 @@ and the actual decision to setup or tear down paths are assumed
 to be handled by the application. But this document does not prevent future extensions from
 defining mechanisms to cope with the remaining scenarios.
 
-Further, this document does not specify scheduling algorithms that define
-how multiple, simultaneously open paths are used to send packets.
-As these differ depending on application requirements,
-only some basic implementation guidance is discussed in {{impl-consideration}}.
-However, scheduling algorithms that may be specified by the IETF in future
-can be used with the multipath extension specified in this document.
+The framework specified in this document can be used with 
+a range of scheduling algorithms that define
+how multiple simultaneously open paths are used to send packets. 
+Examples of schedulers can range from support for failover to simulatenous concurrent
+use of the aggreate capacity across all active paths.
 
+The specification of scheduling for multipath in
+the general Internet is outside the scope of this document.  
+There are existing IETF specifications for path fail-over, but
+concurrently no IETF standards-track specifications for simulatenously
+using the capacity of a set of active paths. 
+
+Because the scheduling policy differs depending on application requirements,
+only some basic implementation guidance is discussed in {{impl-consideration}}.
 Specifically, while failover between Wi-Fi
 and mobile networks is a well-known multipath use case,
-it only uses two paths at the same time temporarily
+it only temporarily uses two paths at the same time 
 to avoid transmission pauses.
-Simultaneous path usage generally, however, needs more consideration
+More general use of simultaneous paths, however, needs more consideration
 than specified in this document to avoid negative performance
 impacts, e.g., when stream data is distributed over multiple paths with
-different delays.
+different delays or to avoid excessive conestion of shared bottlenecks.
 
 ## Conventions and Definitions {#definition}
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -153,7 +153,7 @@ to avoid transmission pauses.
 More general use of simultaneous paths, however, needs more consideration
 than specified in this document to avoid negative performance
 impacts, e.g., when stream data is distributed over multiple paths with
-different delays or to avoid excessive conestion of shared bottlenecks.
+different delays or to avoid excessive congestion of shared bottlenecks.
 
 ## Conventions and Definitions {#definition}
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -138,8 +138,7 @@ how multiple simultaneously open paths are used to send packets.
 Examples of schedulers can range from support for failover to simulatenous
 use of the aggreate capacity across all active paths.
 
-This document does not specify a scheduling algorithm for multipath in
-the general Internet.
+This document does not specify a scheduling algorithm.
 There are IETF specifications for path fail-over, but
 there are currently no IETF standards-track specifications for simultaneously
 (concurrently) using the aggreate capacity of a set of active paths. 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -141,7 +141,8 @@ e.g., can range from support for failover to simulatenous
 use of the aggreate capacity across all active paths.
 There are IETF specifications for path fail-over, but
 there are currently no IETF standards-track specifications for simultaneously
-(concurrently) using the aggregated capacity of a set of active paths. 
+(concurrently) using the aggregated capacity of a set of active paths.
+
 Specifically, while failover between Wi-Fi
 and mobile networks is a well-known multipath use case,
 it only temporarily uses two paths at the same time

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -150,10 +150,10 @@ Specifically, while failover between Wi-Fi
 and mobile networks is a well-known multipath use case,
 it only temporarily uses two paths at the same time 
 to avoid transmission pauses.
-More general use of simultaneous paths, however, needs more consideration
+Simultaneous path usage generally, however, needs more consideration
 than specified in this document to avoid negative performance
 impacts, e.g., when stream data is distributed over multiple paths with
-different delays or to avoid excessive congestion of shared bottlenecks.
+different delays.
 
 ## Conventions and Definitions {#definition}
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -138,7 +138,7 @@ how multiple simultaneously open paths are used to send packets.
 Examples of schedulers can range from support for failover to simulatenous
 use of the aggreate capacity across all active paths.
 
-This document does not specify scheduling for multipath in
+This document does not specify a scheduling algorithm for multipath in
 the general Internet.
 There are IETF specifications for path fail-over, but
 there are currently no IETF standards-track specifications for simultaneously


### PR DESCRIPTION
Here are a bunch of changes that I think cover all my corner cases of what the IETF has STD'ed/what would be regarded as EXP, and the caveats, while hopefully not constraining the use of MP-QUIC. I am super happier about the idea that this appears in the intro, rather than the spec.