### PR TITLE
align terminology: active paths -> open paths

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -316,7 +316,7 @@ issuing and retirement of per-path connection IDs (see
 {{consume-retire-cid}}), path status management (see {{path-state}}) and
 path closure (see {{path-close}}).
 However, this document does not specify when a client decides to initiate or close a path,
-or how multiple active paths are used for sending.
+or how multiple open paths are used for sending.
 
 ## Path Initiation and Validation {#path-initiation}
 


### PR DESCRIPTION
We adjusted the terminology a while back to rather use open (as active includes path with issued path IDs that are not open yet). I used the terminology wrong when I added this sentence with the editorial pass. So fixing this now.