### PR TITLE
using the same path ID, also for PATH_RESPONSE

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -344,7 +344,7 @@ Until the client's address is
 validated, the anti-amplification limit from {{Section 8 of QUIC-TRANSPORT}}
 applies.
 
-If an endpoint sends a PATH_RESPONSE, it MUST be sent one the same path
+If an endpoint sends a PATH_RESPONSE, it MUST be sent on the same path
 as used by the packet that contained the PATH_CHALLENGE frame,
 using a connection ID associated with the same path ID.
 

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -345,7 +345,8 @@ validated, the anti-amplification limit from {{Section 8 of QUIC-TRANSPORT}}
 applies.
 
 If an endpoint sends a PATH_RESPONSE, it MUST be sent one the same path
-as used by the packet that contained the PATH_CHALLENGE frame.
+as used by the packet that contained the PATH_CHALLENGE frame,
+using a connection ID associated with the same path ID.
 
 The server may receive packets for a yet unused path ID that do not
 contain a PATH_CHALLENGE frame. Such packets are valid if they can be properly decrypted

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -326,14 +326,12 @@ or how multiple open paths are used for sending.
 ## Path Initiation and Validation {#path-initiation}
 
 To open a new path, an endpoint MUST use a new connection ID associated
-with an unused path ID. When sending packets on the same path, an endpoint
+with an unused path ID. An endpoint
 MUST use a connection ID associated to the same path ID as used in the packet
-received by the server. If an endpoint receives a PATH_CHALLENGE, the
-PATH_RESPONSE MUST be sent on the same path as the packet that contained
-the PATH_CHALLENGE frame.
+received by the endpoint when it intends to send packets on the same path.
 
 A client that wants to use an
-additional path MUST validate the peer's address before sending any data packets
+new path MUST validate the peer's address before sending any data packets
 as described in {{Section 8.2 of QUIC-TRANSPORT}},
 unless it has previously validated the 4-tuple used for that path.
 
@@ -345,6 +343,9 @@ unless it has previously validated the 4-tuple used for that path.
 Until the client's address is
 validated, the anti-amplification limit from {{Section 8 of QUIC-TRANSPORT}}
 applies.
+
+If an endpoint sends a PATH_RESPONSE, it MUST be sent one the same path
+as used by the packet that contained the PATH_CHALLENGE frame.
 
 The server may receive packets for a yet unused path ID that do not
 contain a PATH_CHALLENGE frame. Such packets are valid if they can be properly decrypted

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -325,11 +325,12 @@ or how multiple open paths are used for sending.
 
 ## Path Initiation and Validation {#path-initiation}
 
-
 To open a new path, an endpoint MUST use a new connection ID associated
-with an unused path ID.
-When sending a PATH_RESPONSE frame, an endpoint MUST use a connection ID associated to
-the same path ID as used in the packet that contained the PATH_CHALLENGE frame.
+with an unused path ID. When sending packets on the same path, an endpoint
+MUST use a connection ID associated to the same path ID as used in the packet
+received by the server. If an endpoint receives a PATH_CHALLENGE, the
+PATH_RESPONSE MUST be sent on the same path as the packet that contained
+the PATH_CHALLENGE frame.
 
 A client that wants to use an
 additional path MUST validate the peer's address before sending any data packets


### PR DESCRIPTION
fixes #546

Proposed rewrite by @huitema to make it more clear that using the same path does not automatically imply sending a PATH_RESPONSE