### PR TITLE
MUST handle migration

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -456,7 +456,7 @@ as long as the anti-amplification limits
 (see {{Section 21.1.1.1 of QUIC-TRANSPORT}}) and the congestion control
 limits for this path are respected.
 
-An endpoint could receive a packet with a connection ID 
+An endpoint could receive a packet with a connection ID
 associated to an active path ID where the packet's 4-tuple does not match the 4-tuple
 currently used with that path ID. This MUST be treated as path migration,
 as specified in {{Section 9.3 of QUIC-TRANSPORT}}, with the constraint that


### PR DESCRIPTION
fixes #549 

This PR adds a MUST for handling migration as proposed by @martinthomson in the issue. I first tried to simple add his proposed sentence here but that didn't make sense as it would say the same thing twice. So maybe this works?

However, I personally am not convinced that this change is an improvement. We didn't want to repeat any MUSTs from RFC9000. So if we don't explicitly change it, those are still valid. Therefore we only added a MUST on the use of CID for the same path ID here. I really don't feel that new MUST here is necessary.