### PR TITLE
Attempt to clarify initial path probing behaviour

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -351,9 +351,12 @@ with an unused path ID. An endpoint
 MUST use a connection ID associated to the same path ID as used in the packet
 received by the endpoint when it intends to send packets on the same path.
 
-A client that wants to use a
-new path MUST validate the peer's address before sending any data
-as described in {{Section 8.2 of QUIC-TRANSPORT}},
+A client can always start address validation by sending an initial
+PATH_CHALLENGE and its retransmits as specified in {{Section 6.2.2.1
+of QUIC-RECOVERY}}.
+However a client that wants to  use a
+new path MUST validate the peer's address before sending any data as
+described in {{Section 8.2 of QUIC-TRANSPORT}},
 unless it has previously validated the 4-tuple used for that path.
 
 After receiving packets from the


### PR DESCRIPTION
This is an attempt to improve understanding one of the two issues discussed in #586.  I'm not particularly happy with this wording, but do think it does add important context to understand what is allowed.  Even if it is not strictly needed from a normative perspective.