### PR TITLE
Make it clear the CIDs are not actually retired

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -718,7 +718,7 @@ packets, but it cannot completely avoid that risk.
 {{Section 10.3 of QUIC-TRANSPORT}} specified that the Stateless Reset Tokens
 associated with retired connection IDs cannot be used to identify Stateless Reset packets.
 Considering the connection IDs received from the peer as immediately retired for an abandoned
-path guarantees that suprious Stateless Reset packets
+path guarantees that spurious Stateless Reset packets
 sent by the peer will not cause the closure of the QUIC connection.
 
 ### Handling PATH_ACK for Abandoned Paths {#ack-after-abandon}

--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -717,8 +717,8 @@ packets, but it cannot completely avoid that risk.
 
 {{Section 10.3 of QUIC-TRANSPORT}} specified that the Stateless Reset Tokens
 associated with retired connection IDs cannot be used to identify Stateless Reset packets.
-The immediate retirement of connection IDs received from the peer for an abandoned
-path guarantees that spurious Stateless Reset packets
+Considering the connection IDs received from the peer as immediately retired for an abandoned
+path guarantees that suprious Stateless Reset packets
 sent by the peer will not cause the closure of the QUIC connection.
 
 ### Handling PATH_ACK for Abandoned Paths {#ack-after-abandon}


### PR DESCRIPTION
The way this was worded suggested that the CIDs are really retired, but that would involve sending PATH_RETIRE_CONNECTION_ID frames for all CIDs of an abandoned path.  This is not required by § 3.4 which only says you need to "treat the CIDs as immediately retired".

Aligning this wording here makes the intention clearer.