### PR TITLE
Parameter frame and error types to desired values

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -189,7 +189,7 @@ only be sent in 1-RTT packets.
 
 The new transport parameter is defined as follows:
 
-- initial_max_path_id (parameter type 0x3e): parameter value is a
+- initial_max_path_id (parameter ID 0x3e): parameter value is a
   variable-length integer specifying the maximum path ID
   an endpoint is willing to maintain at connection initiation.
   This value MUST NOT exceed 2<sup>32</sup>-1, the maximum allowed value for the path ID due to


### PR DESCRIPTION
This PR updates the values of transport parameter type, frame types and error types to the values that were agreed in issue #625.
It also removes the references to provisional assignments, and makes sure that the description of all frames introduce the parameter types in the same manner used in RFC 9000.
The PR also solves one of the issue noted by Adrian Farrel (issue #626) about confusion between TP type and TP value -- because that was directly tied to the way we reference types, and solving that in a different PR would create a merge conflict.