### PR TITLE
Address management concerns

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -161,7 +161,7 @@ The operational considerations for QUIC are addressed in {{RFC9312}}.
 They also apply to QUIC connections using the extensions defined in this
 document. An additional complexity is that applications might use a combination
 of monitored and non-monitored paths, but that complexity already
-exist when using path migration as defined in {{QUIC-TRANSPORT}}.
+exists when using path migration as defined in {{QUIC-TRANSPORT}}.
 
 ## Conventions and Definitions {#definition}
 


### PR DESCRIPTION
This PR addresses the concerns expressed in the Operation Directorate review (see issue #626), adding a short paragraph in the Introduction with a pointer to RFC 9312, as well as a minor edit. The paragraph also addresses the issue of application mixing managed and unmanaged (not monitored) paths noted in the review.

As suggested in the review and discussion, this PR also add a not on transport parameter negotiation enabling incremental deployment.

The review suggested specifying that the initial number of path and the subsequent increments of the number are specified by the application "if not already obvious". This PR does snot add specific text here, because it should indeed be obvious that the numbers are set by the "endpoint", i.e., the combination of QUIC stack and application code. Going further than that would require discussion of how code is implemented, which would probably go beyond the scope of the document.

The PR fixes an editorial issue, replacing the statement that the nonce includes "the least significant 32 bits" of the path ID by "the 32 bits" of the path ID, which is cleared.

The other editorial suggestion are already addressed in PR #628 and #630.