### PR TITLE
Address ART review feedback

### DIFF
--- a/draft-ietf-quic-multipath.md
+++ b/draft-ietf-quic-multipath.md
@@ -1228,7 +1228,7 @@ the endpoint can keep the same congestion control and RTT measurement state.
 PATH_ACK frames indicate which path the acknowledged packets were sent on,
 but they could be received through any open path. If successive acknowledgments are received
 on different paths, the measured RTT samples can fluctuate widely,
-which could result in poor performance depending for example on the congestion control
+which could result in poor performance depending on, for example, the congestion control
 algorithm.
 
 Congestion control state as defined in {{QUIC-RECOVERY}} is kept


### PR DESCRIPTION
Address feedback from ART review:

- clarify that paths MUST be open by client endpoint
- replace "active path limit" reference in discussion of blocked frame by "maximum path ID limit"
- clarify that there is no explicit support in the document to manage creation of path with diffserv controls (as mentioned in 5.2)
- replace stray reference to "connection control" by "congestion control"

Note that the use of 32 bit for nonce is addressed in another PR.